### PR TITLE
Add an extra_args parameter to start-host

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ build: ## 🔨 Build the Application
 # Start hosting the application using `sandbox.sh` and enable custom JWT authentication
 start-host: build  ## 🏃 Start the CCF network using Sandbox.sh
 	@echo -e "\e[34m$@\e[0m" || true
-	$(CCFSB)/sandbox.sh --js-app-bundle ./dist/ --initial-member-count 3 --initial-user-count 1 --constitution ./governance/constitution/kms_actions.js -v
+	$(CCFSB)/sandbox.sh --js-app-bundle ./dist/ --initial-member-count 3 --initial-user-count 1 --constitution ./governance/constitution/kms_actions.js -v $(extra_args)
 
 setup: ## Setup policies and generate a key
 	@echo -e "\e[34m$@\e[0m" || true


### PR DESCRIPTION
This allows use to use the make target `start-host` while specifying the `--http2` option which lets the KMS work with B&A servers