### PR TITLE
Allow to configure extra sandbox args for start-host-idp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ KMS_URL ?= https://127.0.0.1:8000
 KEYS_DIR ?= ${KMS_WORKSPACE}/sandbox_common
 RUN_BACK ?= true
 CCF_PLATFORM ?= virtual
+CCF_SANDBOX_EXTRA_ARGS ?= 
 
 ifeq ($(INSTALL),local)
     CCFSB=../../CCF/tests/sandbox
@@ -55,9 +56,11 @@ start-host-idp: stop-host stop-idp start-idp build ## 🏃 Start the CCF network
 	@echo -e "\e[34m$@\e[0m" || true
 	@echo "Executing: $(COMMAND)"
 	if [ "$(RUN_BACK)" = "true" ]; then \
-		 env -i PATH=${PATH} KMS_WORKSPACE=${KMS_WORKSPACE} $(CCFSB)/sandbox.sh --js-app-bundle ./dist/ --initial-member-count 3 --initial-user-count 1 --constitution ./governance/constitution/kms_actions.js --jwt-issuer ${KMS_WORKSPACE}/proposals/set_jwt_issuer_test_sandbox.json  -v --http2 & \
+		 env -i PATH=${PATH} KMS_WORKSPACE=${KMS_WORKSPACE} $(CCFSB)/sandbox.sh --js-app-bundle ./dist/ --initial-member-count 3 --initial-user-count 1 --constitution ./governance/constitution/kms_actions.js --jwt-issuer ${KMS_WORKSPACE}/proposals/set_jwt_issuer_test_sandbox.json  -v --http2 \
+		 	${CCF_SANDBOX_EXTRA_ARGS} & \
 	else \
-		 env -i PATH=${PATH} KMS_WORKSPACE=${KMS_WORKSPACE} $(CCFSB)/sandbox.sh --js-app-bundle ./dist/ --initial-member-count 3 --initial-user-count 1 --constitution ./governance/constitution/kms_actions.js --jwt-issuer ${KMS_WORKSPACE}/proposals/set_jwt_issuer_test_sandbox.json  -v --http2; \
+		 env -i PATH=${PATH} KMS_WORKSPACE=${KMS_WORKSPACE} $(CCFSB)/sandbox.sh --js-app-bundle ./dist/ --initial-member-count 3 --initial-user-count 1 --constitution ./governance/constitution/kms_actions.js --jwt-issuer ${KMS_WORKSPACE}/proposals/set_jwt_issuer_test_sandbox.json  -v --http2 \
+		 	${CCF_SANDBOX_EXTRA_ARGS};  \
 	fi
 
 demo: stop-all start-idp ## 🎬 Demo the KMS Application in the Sandbox

--- a/scripts/kms_wait.sh
+++ b/scripts/kms_wait.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 
+KMS_URL="${KMS_URL:-https://127.0.0.1:8000}"
 response_code=000
 echo "Waiting for KMS to start..."
 while ! [[ $response_code -eq 400 || $response_code -eq 200 ]]; do
     sleep 1
-    response_code=$(curl https://127.0.0.1:8000/app/listpubkeys -k -s -o /dev/null -w "%{http_code}")
+    response_code=$(curl $KMS_URL/app/listpubkeys -k -s -o /dev/null -w "%{http_code}")
 done
 echo "KMS started"


### PR DESCRIPTION
- Edit scripts/kms_wait.sh so that it respects KMS_URL
- Add CCF_SANDBOX_EXTRA_ARGS to start-host-idp so that it can be used for browser testing

Internal dev repository PR: https://github.com/microsoft/privacy-sandbox-dev/pull/67