### PR TITLE
Specify nohup.out path explicitly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ stop-all: stop-host stop-idp # Stop all services
 start-idp:  ## 🏃 Start the idp for testing jwt
 	@echo -e "\e[34m$@\e[0m" || true
 	mkdir -p ${KMS_WORKSPACE}
-	cd test/utils/jwt && KMS_WORKSPACE=${KMS_WORKSPACE} nohup npm run start  &
+	cd test/utils/jwt && KMS_WORKSPACE=${KMS_WORKSPACE} nohup npm run start > nohup.out 2>&1 &
 	./scripts/wait_idp_ready.sh
 
 # Start hosting the application using `sandbox.sh` and enable custom JWT authentication


### PR DESCRIPTION
It makes sure that the path is always `test/utils/jwt/nohup.out`. It's not the case in CI at the moment.

The manual says:
```
If standard output is a terminal, append output to
       'nohup.out' if possible, '$HOME/nohup.out' otherwise.  If
       standard error is a terminal, redirect it to standard output.  To
       save output to FILE, use 'nohup COMMAND > FILE'.

       NOTE: your shell may have its own version of nohup, which usually
       supersedes the version described here.  Please refer to your
       shell's documentation for details about the options it supports.
```

https://man7.org/linux/man-pages/man1/nohup.1.html

So it should be safer to specify the nohup.out path explicitly.

It doesn't break the CI in dev repo: https://github.com/microsoft/privacy-sandbox-dev/pull/153/commits/c9782712ddd4a85f2d3c6dbdc52e417bff46dfe8
