### PR TITLE
Create a run container without build files

### DIFF
--- a/.github/Dockerfile.ci
+++ b/.github/Dockerfile.ci
@@ -22,5 +22,8 @@ RUN /kms/install_packages.sh
 RUN /kms/install_nodejs.sh
 RUN /kms/setup_tinkey.sh
 # "All necessary packages and tinkey setup completed."
+
 RUN ls -la /kms
-RUN /kms/set_python_env.sh && npm i && make build
+RUN /kms/set_python_env.sh
+RUN npm install 
+RUN make build

--- a/.github/Dockerfile.ci
+++ b/.github/Dockerfile.ci
@@ -8,10 +8,18 @@ ARG ENVIRONMENT=ci
 # hadolint ignore=DL3006
 FROM mcr.microsoft.com/ccf/app/dev:${BASE_CCF_IMAGE} as base
 
-COPY .devcontainer/install_packages.sh .devcontainer/install_nodejs.sh .devcontainer/setup_tinkey.sh /src/
+COPY .devcontainer/install_packages.sh \ 
+    .devcontainer/install_nodejs.sh \
+    .devcontainer/setup_tinkey.sh \
+    scripts/set_python_env.sh \
+    /kms/
+
+WORKDIR /kms
 
 # "Install necessary packages."
-RUN /src/install_packages.sh
-RUN /src/install_nodejs.sh
-RUN /src/setup_tinkey.sh
+RUN install_packages.sh
+RUN install_nodejs.sh
+RUN setup_tinkey.sh
 # "All necessary packages and tinkey setup completed."
+
+RUN set_python_env.sh && npm i && make build

--- a/.github/Dockerfile.ci
+++ b/.github/Dockerfile.ci
@@ -13,13 +13,14 @@ COPY .devcontainer/install_packages.sh \
     .devcontainer/setup_tinkey.sh \
     scripts/set_python_env.sh \
     /kms/
+COPY . /kms
 
 WORKDIR /kms
 
 # "Install necessary packages."
-RUN install_packages.sh
-RUN install_nodejs.sh
-RUN setup_tinkey.sh
+RUN /kms/install_packages.sh
+RUN /kms/install_nodejs.sh
+RUN /kms/setup_tinkey.sh
 # "All necessary packages and tinkey setup completed."
 
-RUN set_python_env.sh && npm i && make build
+RUN /kms/set_python_env.sh && npm i && make build

--- a/.github/Dockerfile.ci
+++ b/.github/Dockerfile.ci
@@ -22,5 +22,5 @@ RUN /kms/install_packages.sh
 RUN /kms/install_nodejs.sh
 RUN /kms/setup_tinkey.sh
 # "All necessary packages and tinkey setup completed."
-
+RUN ls -la /kms
 RUN /kms/set_python_env.sh && npm i && make build

--- a/.github/Dockerfile.ci.dockerignore
+++ b/.github/Dockerfile.ci.dockerignore
@@ -1,0 +1,7 @@
+**/dist
+**/node_modules
+**/package-lock.json
+**/workspace
+**/nohup.out
+**.log
+**/.venv_ccf_sandbox

--- a/.github/devcontainer.json
+++ b/.github/devcontainer.json
@@ -4,7 +4,6 @@
     "dockerfile": "Dockerfile.ci",
     "context": ".."
   },
-  "postCreateCommand": "cd /workspaces/azure-privacy-sandbox-kms && scripts/set_python_env.sh && npm i && make build",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {
       "version": "latest",


### PR DESCRIPTION
The current docker CI is bases on devcontainer.
The new container will have a build image and a run image so a minimal container is used in production