### PR TITLE
Improve runtime docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 ARG CCF_PLATFORM
-ARG CCF_VERSION=5.0.0-rc0
+ARG CCF_VERSION=5.0.0-dev10
 
 # Build Image ------------------------------------------------------------------
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -41,6 +41,7 @@ ARG CCF_PLATFORM
 RUN apt-get update && apt-get install -y lsof
 
 COPY --from=builder /kms /kms
+WORKDIR /kms
 
 # Install Node to run IDP (Currently bundled to KMS but should be separated)
 ENV CCF_PLATFORM=${CCF_PLATFORM} PATH=/kms/.nvm/versions/node/v22.5.1/bin/:$PATH

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,8 +3,7 @@ ARG CCF_VERSION=5.0.0-dev10
 
 # Build Image ------------------------------------------------------------------
 
-FROM mcr.microsoft.com/ccf/app/dev:${CCF_VERSION}-${CCF_PLATFORM} AS builder
-ARG CCF_PLATFORM
+FROM mcr.microsoft.com/ccf/app/dev:${CCF_VERSION}-virtual AS builder
 
 COPY .devcontainer/install_packages.sh /src/
 RUN /src/install_packages.sh
@@ -12,6 +11,10 @@ RUN /src/install_packages.sh
 COPY .devcontainer/install_nodejs.sh /src/
 ENV NVM_DIR /kms/.nvm
 RUN /src/install_nodejs.sh
+
+COPY .devcontainer/setup_tinkey.sh /src/
+ENV TINKEY_VERSION=tinkey-1.10.1
+RUN /src/setup_tinkey.sh
 
 # Copy minimal set of files to build KMS bundle to reduce rebuilds
 COPY Makefile /kms/Makefile
@@ -23,26 +26,24 @@ COPY requirements.txt /kms/requirements.txt
 COPY rollup.config.js /kms/rollup.config.js
 COPY app.json /kms/app.json
 COPY build_bundle.js /kms/build_bundle.js
+COPY babel.config.json /kms/babel.config.json
+COPY buf.gen.yaml /kms/buf.gen.yaml
+COPY loader-register.js /kms/loader-register.js
+COPY test /kms/test
 COPY tsconfig.json /kms/tsconfig.json
 
 WORKDIR /kms
 RUN make build
-
-# Needed because the code to run a dummy idp is in test/utils/jwt
-COPY test /kms/test
 
 # Run Image --------------------------------------------------------------------
 
 # While KMS relies on running on sandbox.sh we need to use dev image
 # FROM mcr.microsoft.com/ccf/app/run-js:${CCF_VERSION}-${CCF_PLATFORM}
 FROM mcr.microsoft.com/ccf/app/dev:${CCF_VERSION}-${CCF_PLATFORM}
-ARG CCF_PLATFORM
-
-RUN apt-get update && apt-get install -y lsof
 
 COPY --from=builder /kms /kms
 WORKDIR /kms
 
-# Install Node to run IDP (Currently bundled to KMS but should be separated)
+ARG CCF_PLATFORM
 ENV CCF_PLATFORM=${CCF_PLATFORM} PATH=/kms/.nvm/versions/node/v22.5.1/bin/:$PATH
-CMD ["/bin/bash", "-c", "cd /kms && (make start-host-idp & (./scripts/kms_wait.sh && make setup && tail -f /dev/null))"]
+CMD ["/bin/bash", "-c", "make start-host-idp & (./scripts/kms_wait.sh && make setup && tail -f /dev/null)"]


### PR DESCRIPTION
- Use stable version of CCF
- Add some missing files
- Make consistent interface with privacy-sandbox-dev
- Make rebuilds of snp and virtual KMS's more efficient