### PR TITLE
Add script to add hostdata value to the key release policy

### DIFF
--- a/scripts/add_hostdata_keyreleasepolicy.sh
+++ b/scripts/add_hostdata_keyreleasepolicy.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+set -euo pipefail
+
+function usage {
+    echo ""
+    echo "Add hostdata to the key release policy."
+    echo ""
+    echo "usage: ./add_hostdata_keyreleasepolicy.sh --network-url string  --hostdata string --certificate-dir <workspace/sandbox_common> string"
+    echo ""
+    echo "  --network-url               string      ccf network url (example: https://test.confidential-ledger.azure.com)"
+    echo "  --certificate-dir           string      The directory where the certificates are"
+    echo "  --hostdata                  string      hostdata value we want to add to the key release policy"
+    echo "  --member-count              number      number of network members need to approve the proposal"
+    echo ""
+    exit 0
+}
+
+function failed {
+    printf "Script failed: %s\n\n" "$1"
+    exit 1
+}
+
+# Initialize the variables to empty strings
+network_url=""
+certificate_dir=""
+hostdata=""
+member_count=1
+
+while [ $# -gt 0 ]
+do
+    name="${1/--/}"
+    name="${name/-/_}"
+    case "--$name"  in
+        --network_url) network_url="$2"; shift;;
+        --hostdata) hostdata="$2"; shift;;
+        --certificate_dir) certificate_dir="$2"; shift;;
+        --member_count) member_count=$2; shift;;
+        --help) usage; exit 0; shift;;
+        --) shift;;
+    esac
+    shift;
+done
+
+# Escape double quotes
+slurp_file() {
+  cat "$1" | sed 's/"/\\"/g'
+}
+
+echo "Network URL: $network_url"
+echo "Certificate Directory: $certificate_dir"
+echo "Hostdata: $hostdata"
+
+# validate parameters
+if [[ -z $network_url ]]; then
+    failed "Missing parameter --network-url"
+elif [[ -z $certificate_dir ]]; then
+   failed "You must supply --certificate-dir"
+elif [[ -z $hostdata ]]; then
+   failed "You must supply --hostdata"
+fi
+
+common_dir=$certificate_dir  # common folder
+
+service_cert="$certificate_dir/service_cert.pem"
+signing_cert="$certificate_dir/member0_cert.pem"
+signing_key="$certificate_dir/member0_privk.pem"
+
+echo "Add hostdata policy: $hostdata"
+# Create the JSON content
+json_key_release_policy=$(cat <<EOF
+{
+  "actions": [
+    {
+      "name": "set_key_release_policy",
+      "args": {
+        "service": "some service",
+        "type": "add",
+        "claims": {
+          "x-ms-sevsnpvm-hostdata": "$hostdata"
+        }
+      }
+    }
+  ]
+}
+EOF
+)
+echo "$json_key_release_policy" > "$common_dir/hostdata_krp.json"
+
+# Read the file and output its content as a string
+#escaped_js=$(jq -Rs . < "$common_dir/constitution.js")
+#serialized="$escaped_js"
+
+# propose and vote
+./scripts/submit_proposal.sh --network-url  "${network_url}" --proposal-file "$common_dir/hostdata_krp.json" --certificate-dir  "${certificate_dir}" --member-count ${member_count}

--- a/test/e2e-test/src/index.ts
+++ b/test/e2e-test/src/index.ts
@@ -302,9 +302,10 @@ class Demo {
 
 
     console.log(`📝 Get initial key-Bad hostdata in key release policy...`);
-    await Demo.executeCommand(
+    let hostdataResp = await Demo.executeCommand(
       `./scripts/add_hostdata_keyreleasepolicy.sh --network_url $KMS_URL --certificate_dir $KEYS_DIR --hostdata 73973b78xxx`,
     );
+    console.log("hostdataResp: ", hostdataResp);
     [headers, statusCode, keyResponse] = await Api.key(
       this.demoProps,
       member,
@@ -323,9 +324,10 @@ class Demo {
     Demo.assert("bad hostdata", statusCode == 400);
 
     // Set correct hostdata so the rest of test will pass
-    await Demo.executeCommand(
+    hostdataResp = await Demo.executeCommand(
       `./scripts/add_hostdata_keyreleasepolicy.sh --network_url $KMS_URL --certificate_dir $KEYS_DIR --hostdata 73973b78d70cc68353426de188db5dfc57e5b766e399935fb73a61127ea26d20`,
     );
+    console.log("hostdataResp: ", hostdataResp);
 
     // Test with JWT
     console.log(`📝 Get wrapped key with JWT...`);

--- a/test/e2e-test/src/index.ts
+++ b/test/e2e-test/src/index.ts
@@ -126,8 +126,6 @@ class Demo {
       .replace(/\\n/g, "\n");
     console.log(`Private wrapping key: `, private_wrapping_key);
 
-    process.chdir("../../");
-
     this.printTestSectionHeader("🔬 [TEST]: Key generation Service");
 
     const notUndefinedString = (key: string | number | any[]) => {
@@ -301,6 +299,33 @@ class Demo {
         throw new Error(`🛑 [TEST FAILURE]: Expected ${statusCode} to be 200`);
       }
     } while (statusCode !== 200);
+
+
+    console.log(`📝 Get initial key-Bad hostdata in key release policy...`);
+    await Demo.executeCommand(
+      `./scripts/add_hostdata_keyreleasepolicy.sh --network_url $KMS_URL --certificate_dir $KEYS_DIR --hostdata 73973b78xxx`,
+    );
+    [headers, statusCode, keyResponse] = await Api.key(
+      this.demoProps,
+      member,
+      attestation,
+      private_wrapping_key,
+      public_wrapping_key,
+      false,
+      undefined,
+      this.createHttpsAgent(member.id, AuthKinds.JWT),
+      access_token,
+    ).catch((error) => {
+      console.log(`keyInitial error: `, error);
+      throw error;
+    });
+    console.log(`response bad hostdata: `, keyResponse);
+    Demo.assert("bad hostdata", statusCode == 400);
+
+    // Set correct hostdata so the rest of test will pass
+    await Demo.executeCommand(
+      `./scripts/add_hostdata_keyreleasepolicy.sh --network_url $KMS_URL --certificate_dir $KEYS_DIR --hostdata 73973b78d70cc68353426de188db5dfc57e5b766e399935fb73a61127ea26d20`,
+    );
 
     // Test with JWT
     console.log(`📝 Get wrapped key with JWT...`);

--- a/test/e2e-test/src/index.ts
+++ b/test/e2e-test/src/index.ts
@@ -301,33 +301,6 @@ class Demo {
     } while (statusCode !== 200);
 
 
-    console.log(`📝 Get initial key-Bad hostdata in key release policy...`);
-    let hostdataResp = await Demo.executeCommand(
-      `./scripts/add_hostdata_keyreleasepolicy.sh --network_url $KMS_URL --certificate_dir $KEYS_DIR --hostdata 73973b78xxx`,
-    );
-    console.log("hostdataResp: ", hostdataResp);
-    [headers, statusCode, keyResponse] = await Api.key(
-      this.demoProps,
-      member,
-      attestation,
-      private_wrapping_key,
-      public_wrapping_key,
-      false,
-      undefined,
-      this.createHttpsAgent(member.id, AuthKinds.JWT),
-      access_token,
-    ).catch((error) => {
-      console.log(`keyInitial error: `, error);
-      throw error;
-    });
-    console.log(`response bad hostdata: `, keyResponse);
-    Demo.assert("bad hostdata", statusCode == 400);
-
-    // Set correct hostdata so the rest of test will pass
-    hostdataResp = await Demo.executeCommand(
-      `./scripts/add_hostdata_keyreleasepolicy.sh --network_url $KMS_URL --certificate_dir $KEYS_DIR --hostdata 73973b78d70cc68353426de188db5dfc57e5b766e399935fb73a61127ea26d20`,
-    );
-    console.log("hostdataResp: ", hostdataResp);
 
     // Test with JWT
     console.log(`📝 Get wrapped key with JWT...`);


### PR DESCRIPTION
The new scripts/add_hostdata_keyreleasepolicy.sh allow us to add hostdata to  the key release policy.

Usage:
scripts/add_hostdata_keyreleasepolicy.sh --network_url $KMS_URL --certificate_dir $KEYS_DIR --hostdata 73973b78d70cc68353426de188db5dfc57e5b766e399935fb73a61127ea26d20

This adds the hostdata in our test attestation to the key release policy