### PR TITLE
Set forwarding_required in app.json to always

### DIFF
--- a/app.json
+++ b/app.json
@@ -250,7 +250,7 @@
       "post": {
         "js_module": "endpoints/refreshEndpoint.js",
         "js_function": "refresh",
-        "forwarding_required": "sometimes",
+        "forwarding_required": "always",
         "authn_policies": [],
         "mode": "readwrite",
         "openapi": {


### PR DESCRIPTION
Set forwarding_required in app.json to always. This fixes service not available in mCCF.