### PR TITLE
Fix kid bug

### DIFF
--- a/src/endpoints/refreshEndpoint.ts
+++ b/src/endpoints/refreshEndpoint.ts
@@ -33,9 +33,10 @@ export const refresh = (
     // Get HPKE key pair id
     const id = hpkeKeyIdMap.size + 1;
 
-    // Generate HPKE key pair with a six digit id
-    const keyItem = KeyGeneration.generateKeyItem(100000 + id);
-
+    // since OHTTP is limited to 2 char ids, we can only have ids from 10 to 99
+    // So the current logic is to have ids rotate from 10 to 99
+    const keyItem = KeyGeneration.generateKeyItem(id % 90 + 10);
+    
     // Store HPKE key pair kid
     keyItem.kid = `${keyItem.kid!}_${id}`;
     hpkeKeyIdMap.storeItem(id, keyItem.kid);

--- a/test/e2e-test/src/index.ts
+++ b/test/e2e-test/src/index.ts
@@ -541,7 +541,7 @@ class Demo {
     Demo.assertField(member.name, keyResponse, "receipt", notUndefinedString);
 
     Demo.assert(`keyResponse.timestamp > 0`, keyResponse.timestamp > 0);
-    Demo.assert(`keyResponse.id > 100000`, keyResponse.id > 100000);
+    Demo.assert(`keyResponse.id > 10`, keyResponse.id > 10);
     //#endregion
 
     //#region listpubkeys

--- a/test/system-test/test_pubkey.py
+++ b/test/system-test/test_pubkey.py
@@ -15,7 +15,7 @@ def test_no_params_with_single_key(setup_kms):
         if status_code != 202:
             break
     assert status_code == 200
-    assert key_json["id"] == 100001
+    assert key_json["id"] == 11
 
 
 def test_no_params_with_multiple_keys(setup_kms):
@@ -26,7 +26,7 @@ def test_no_params_with_multiple_keys(setup_kms):
         if status_code != 202:
             break
     assert status_code == 200
-    assert key_json["id"] == 100002
+    assert key_json["id"] == 12
 
 
 def test_kid_not_present_with_other_keys(setup_kms):


### PR DESCRIPTION
Make kid change done by @sureshchaha and make sure CI is passing.
OHTTP works with a 2 digit kid. Kid space reduced to 10-99.