### PR TITLE
Tail kms logs instead of /dev/null

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -49,4 +49,4 @@ WORKDIR /kms
 
 ARG CCF_PLATFORM
 ENV CCF_PLATFORM=${CCF_PLATFORM}
-CMD ["/bin/bash", "-c", "make start-host-idp & (./scripts/kms_wait.sh && make setup && tail -f /dev/null)"]
+CMD ["/bin/bash", "-c", "make start-host-idp & (./scripts/kms_wait.sh && make setup && tail -f /kms/workspace/sandbox_0/out)"]


### PR DESCRIPTION
This change adds logs from the CCF network and KMS to the container logs.

This gives us a better understanding of what the KMS is doing, previously we were only emitting logs from the setup process