### PR TITLE
print log and add daily schedule for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,9 @@ jobs:
           runCmd: |
              scripts/set_python_env.sh && pip install -r requirements.txt
              make demo
-             cat workspace/sandbox_0/out
+
+      - name: Print CCF logs
+        run: cat workspace/sandbox_0/out
 
   system:
     secrets: inherit # pragma: allowlist secret

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,9 @@ jobs:
           configFile: .devcontainer/devcontainer.json
           runCmd: |
              scripts/set_python_env.sh && pip install -r requirements.txt
-             make demo
+
+      - name: KMS E2E tests
+        run: make demo
 
       - name: Print CCF logs
         run: cat workspace/sandbox_0/out

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: ./scripts/tools/install-deps.sh
 
-      - name: Build DevContainer
+      - name: Build DevContainer and run E2E tests
         uses: devcontainers/ci@v0.3
         env:
           GH_TOKEN: ${{ github.token }}
@@ -57,9 +57,7 @@ jobs:
           configFile: .devcontainer/devcontainer.json
           runCmd: |
              scripts/set_python_env.sh && pip install -r requirements.txt
-
-      - name: KMS E2E tests
-        run: make demo
+             make demo
 
       - name: Print CCF logs
         run: cat workspace/sandbox_0/out

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ on:
   pull_request:
     branches: [main]
   workflow_dispatch:
+  schedule:
+    - cron: "0 23 * * *"
 
 jobs:
   lint:
@@ -56,6 +58,7 @@ jobs:
           runCmd: |
              scripts/set_python_env.sh && pip install -r requirements.txt
              make demo
+             cat workspace/sandbox_0/out
 
   system:
     secrets: inherit # pragma: allowlist secret


### PR DESCRIPTION
After the e2e tests we print out the CCF log file.
Add a daily schedule to run CI 