### PR TITLE
Run `az-cleanroom-aci` tests in parallel

### DIFF
--- a/.github/workflows/endpoint-test.yml
+++ b/.github/workflows/endpoint-test.yml
@@ -26,7 +26,7 @@ jobs:
           - env: sandbox_local
             threads: 1
           - env: az-cleanroom-aci
-            threads: 1
+            threads: auto
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/scripts/ccf/az-cleanroom-aci/down.sh
+++ b/scripts/ccf/az-cleanroom-aci/down.sh
@@ -15,6 +15,7 @@ az-cleanroom-aci-down() {
 
     az cleanroom ccf network delete \
         --name ${DEPLOYMENT_NAME} \
+        --provider-client "$DEPLOYMENT_NAME-provider" \
         --provider-config $WORKSPACE/providerConfig.json \
         --delete-option delete-storage
 

--- a/scripts/ccf/az-cleanroom-aci/up.sh
+++ b/scripts/ccf/az-cleanroom-aci/up.sh
@@ -19,12 +19,14 @@ az-cleanroom-aci-up() {
     az cleanroom ccf network up \
         --subscription $SUBSCRIPTION \
         --resource-group $RESOURCE_GROUP \
+        --provider-client "$DEPLOYMENT_NAME-provider" \
         --name $DEPLOYMENT_NAME \
 
     export WORKSPACE=~/$DEPLOYMENT_NAME.ccfworkspace
     export KMS_URL=$( \
         az cleanroom ccf network show \
             --name ${DEPLOYMENT_NAME} \
+            --provider-client "$DEPLOYMENT_NAME-provider" \
             --provider-config $WORKSPACE/providerConfig.json \
             | jq -r '.endpoint' \
     )


### PR DESCRIPTION
This is currently blocked on https://github.com/Azure/azure-cleanroom/pull/12 so raising as a separate PR