### PR TITLE
Add AKV support to system tests

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -66,3 +66,31 @@ jobs:
               --resource-group "$RESOURCE_GROUP" \
               --yes
           done
+
+  cleanup-akv:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log into Azure
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.MANAGED_ID_CLIENT_ID }}
+          tenant-id: ${{ secrets.MANAGED_ID_TENANT_ID }}
+          subscription-id: 7ca35580-fc67-469c-91a7-68b38569ca6e
+
+      - run: |
+          source services/cacitesting.env
+          key_vaults=$(az keyvault list \
+            --resource-group "$RESOURCE_GROUP" \
+            --query "[].name" \
+            -o tsv \
+          )
+
+          for kv in $key_vaults; do
+            echo "Deleting Key Vault: $kv"
+            az keyvault delete \
+              --name "$kv" \
+              --resource-group "$RESOURCE_GROUP" > /dev/null 2>&1
+          done

--- a/.github/workflows/endpoint-test.yml
+++ b/.github/workflows/endpoint-test.yml
@@ -53,7 +53,6 @@ jobs:
           TEST_ENVIRONMENT: ccf/${{ matrix.config.env }}
           USE_AKV: ${{ matrix.config.use_akv }}
         run: |
-          source ./scripts/jwt_issuer/up.sh
           pytest -sv \
             test/system-test/test_${{ inputs.endpoint }}.py \
             -n ${{ matrix.config.threads }}

--- a/.github/workflows/endpoint-test.yml
+++ b/.github/workflows/endpoint-test.yml
@@ -51,3 +51,38 @@ jobs:
           pytest -sv \
             test/system-test/test_${{ inputs.endpoint }}.py \
             -n ${{ matrix.config.threads }}
+
+  endpoint-akv:
+    name: ${{ inputs.endpoint }} (${{ matrix.config.env }}) (AKV)
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - env: sandbox_local
+            threads: 1
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log into Azure
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.MANAGED_ID_CLIENT_ID }}
+          tenant-id: ${{ secrets.MANAGED_ID_TENANT_ID }}
+          subscription-id: 7ca35580-fc67-469c-91a7-68b38569ca6e
+
+      - name: Install Dependencies
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: ./scripts/tools/install-deps.sh
+
+      - name: Run System Tests
+        env:
+          TEST_ENVIRONMENT: ccf/${{ matrix.config.env }}
+          USE_AKV: true
+        run: |
+          source ./scripts/jwt_issuer/up.sh
+          pytest -sv \
+            test/system-test/test_${{ inputs.endpoint }}.py \
+            -n ${{ matrix.config.threads }}

--- a/.github/workflows/endpoint-test.yml
+++ b/.github/workflows/endpoint-test.yml
@@ -17,15 +17,20 @@ on:
 jobs:
 
   endpoint:
-    name: ${{ inputs.endpoint }} (${{ matrix.config.env }})
+    name: ${{ inputs.endpoint }} (${{ matrix.config.env }} ({{ matrix.config.use_akv && 'akv' || 'local' }} keys))
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         config:
           - env: sandbox_local
+            use_akv: false
+            threads: 1
+          - env: sandbox_local
+            use_akv: true
             threads: 1
           - env: az-cleanroom-aci
+            use_akv: false
             threads: auto
     steps:
       - name: Checkout
@@ -46,41 +51,7 @@ jobs:
       - name: Run System Tests
         env:
           TEST_ENVIRONMENT: ccf/${{ matrix.config.env }}
-        run: |
-          source ./scripts/jwt_issuer/up.sh
-          pytest -sv \
-            test/system-test/test_${{ inputs.endpoint }}.py \
-            -n ${{ matrix.config.threads }}
-
-  endpoint-akv:
-    name: ${{ inputs.endpoint }} (${{ matrix.config.env }}) (AKV)
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        config:
-          - env: sandbox_local
-            threads: 1
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Log into Azure
-        uses: azure/login@v2
-        with:
-          client-id: ${{ secrets.MANAGED_ID_CLIENT_ID }}
-          tenant-id: ${{ secrets.MANAGED_ID_TENANT_ID }}
-          subscription-id: 7ca35580-fc67-469c-91a7-68b38569ca6e
-
-      - name: Install Dependencies
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: ./scripts/tools/install-deps.sh
-
-      - name: Run System Tests
-        env:
-          TEST_ENVIRONMENT: ccf/${{ matrix.config.env }}
-          USE_AKV: true
+          USE_AKV: ${{ matrix.config.use_akv }}
         run: |
           source ./scripts/jwt_issuer/up.sh
           pytest -sv \

--- a/.github/workflows/endpoint-test.yml
+++ b/.github/workflows/endpoint-test.yml
@@ -17,7 +17,7 @@ on:
 jobs:
 
   endpoint:
-    name: ${{ inputs.endpoint }} (${{ matrix.config.env }} ({{ matrix.config.use_akv && 'akv' || 'local' }} keys))
+    name: ${{ inputs.endpoint }} (${{ matrix.config.env }} (${{ matrix.config.use_akv && 'akv' || 'local' }}_keys))
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/endpoint-test.yml
+++ b/.github/workflows/endpoint-test.yml
@@ -17,7 +17,7 @@ on:
 jobs:
 
   endpoint:
-    name: ${{ inputs.endpoint }} (${{ matrix.config.env }} (${{ matrix.config.use_akv && 'akv' || 'local' }}_keys))
+    name: ${{ inputs.endpoint }} (${{ matrix.config.env }}) (${{ matrix.config.use_akv && 'akv' || 'local' }}_keys)
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -25,6 +25,7 @@ jobs:
           echo "tests=$JSON_ARRAY" | sed ':a;N;$!ba;s/\n//g' >> $GITHUB_OUTPUT
 
   endpoint:
+    name: endpoint
     needs: discover-tests
     secrets: inherit # pragma: allowlist secret
     strategy:

--- a/scripts/akv/down.sh
+++ b/scripts/akv/down.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+akv-down() {
+    set -e
+
+    REPO_ROOT="$(realpath "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../..")"
+
+    source $REPO_ROOT/services/cacitesting.env
+    AKV_NAME=${AKV_NAME:-$1}
+    if [ -z "$AKV_NAME" ]; then
+        read -p "Enter AKV name: " AKV_NAME
+    fi
+
+    az keyvault delete \
+        --resource-group $RESOURCE_GROUP \
+        --name $AKV_NAME
+
+    unset AKV_NAME
+
+    set +e
+}
+
+akv-down "$@"

--- a/scripts/akv/down.sh
+++ b/scripts/akv/down.sh
@@ -9,16 +9,16 @@ akv-down() {
     REPO_ROOT="$(realpath "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../..")"
 
     source $REPO_ROOT/services/cacitesting.env
-    AKV_NAME=${AKV_NAME:-$1}
-    if [ -z "$AKV_NAME" ]; then
-        read -p "Enter AKV name: " AKV_NAME
+    AKV_VAULT_NAME=${AKV_VAULT_NAME:-$1}
+    if [ -z "$AKV_VAULT_NAME" ]; then
+        read -p "Enter AKV name: " AKV_VAULT_NAME
     fi
 
     az keyvault delete \
         --resource-group $RESOURCE_GROUP \
-        --name $AKV_NAME
+        --name $AKV_VAULT_NAME
 
-    unset AKV_NAME
+    unset AKV_VAULT_NAME
 
     set +e
 }

--- a/scripts/akv/key-import.sh
+++ b/scripts/akv/key-import.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+akv-key-import() {
+    set -e
+
+    AKV_NAME=${AKV_NAME:-$1}
+    if [ -z "$AKV_NAME" ]; then
+        read -p "Enter AKV name: " AKV_NAME
+    fi
+    export AKV_NAME
+
+    AKV_KEY_NAME=${AKV_KEY_NAME:-$1}
+    if [ -z "$AKV_KEY_NAME" ]; then
+        read -p "Enter AKV Key name: " AKV_KEY_NAME
+    fi
+    export AKV_KEY_NAME
+
+    az keyvault key import \
+        --vault-name $AKV_NAME \
+        --name $AKV_KEY_NAME \
+        --pem-file $KMS_MEMBER_PRIVK_PATH
+
+    set +e
+}
+
+akv-key-import "$@"
+
+jq -n '{
+    AKV_KEY_NAME: env.AKV_KEY_NAME,
+}'

--- a/scripts/akv/key-import.sh
+++ b/scripts/akv/key-import.sh
@@ -6,11 +6,11 @@
 akv-key-import() {
     set -e
 
-    AKV_NAME=${AKV_NAME:-$1}
-    if [ -z "$AKV_NAME" ]; then
-        read -p "Enter AKV name: " AKV_NAME
+    AKV_VAULT_NAME=${AKV_VAULT_NAME:-$1}
+    if [ -z "$AKV_VAULT_NAME" ]; then
+        read -p "Enter AKV name: " AKV_VAULT_NAME
     fi
-    export AKV_NAME
+    export AKV_VAULT_NAME
 
     AKV_KEY_NAME=${AKV_KEY_NAME:-$1}
     if [ -z "$AKV_KEY_NAME" ]; then
@@ -19,7 +19,7 @@ akv-key-import() {
     export AKV_KEY_NAME
 
     az keyvault key import \
-        --vault-name $AKV_NAME \
+        --vault-name $AKV_VAULT_NAME \
         --name $AKV_KEY_NAME \
         --pem-file $KMS_MEMBER_PRIVK_PATH
 

--- a/scripts/akv/up.sh
+++ b/scripts/akv/up.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+akv-up() {
+    set -e
+
+    REPO_ROOT="$(realpath "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../..")"
+
+    source $REPO_ROOT/services/cacitesting.env
+    AKV_NAME=${AKV_NAME:-$1}
+    if [ -z "$AKV_NAME" ]; then
+        read -p "Enter AKV name: " AKV_NAME
+    fi
+    export AKV_NAME
+
+    if ! az keyvault show --name $AKV_NAME --resource-group $RESOURCE_GROUP &>/dev/null; then
+        az keyvault create \
+            --resource-group $RESOURCE_GROUP \
+            --name $AKV_NAME
+    fi
+
+    export AKV_URL=$(az keyvault show --name $AKV_NAME --query properties.vaultUri -o tsv)
+
+    set +e
+}
+
+akv-up "$@"
+
+jq -n '{
+    AKV_NAME: env.AKV_NAME,
+    AKV_URL: env.AKV_URL,
+}'

--- a/scripts/akv/up.sh
+++ b/scripts/akv/up.sh
@@ -9,19 +9,19 @@ akv-up() {
     REPO_ROOT="$(realpath "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../..")"
 
     source $REPO_ROOT/services/cacitesting.env
-    AKV_NAME=${AKV_NAME:-$1}
-    if [ -z "$AKV_NAME" ]; then
-        read -p "Enter AKV name: " AKV_NAME
+    AKV_VAULT_NAME=${AKV_VAULT_NAME:-$1}
+    if [ -z "$AKV_VAULT_NAME" ]; then
+        read -p "Enter AKV name: " AKV_VAULT_NAME
     fi
-    export AKV_NAME
+    export AKV_VAULT_NAME
 
-    if ! az keyvault show --name $AKV_NAME --resource-group $RESOURCE_GROUP &>/dev/null; then
+    if ! az keyvault show --name $AKV_VAULT_NAME --resource-group $RESOURCE_GROUP &>/dev/null; then
         az keyvault create \
             --resource-group $RESOURCE_GROUP \
-            --name $AKV_NAME
+            --name $AKV_VAULT_NAME
     fi
 
-    export AKV_URL=$(az keyvault show --name $AKV_NAME --query properties.vaultUri -o tsv)
+    export AKV_URL=$(az keyvault show --name $AKV_VAULT_NAME --query properties.vaultUri -o tsv)
 
     set +e
 }
@@ -29,6 +29,6 @@ akv-up() {
 akv-up "$@"
 
 jq -n '{
-    AKV_NAME: env.AKV_NAME,
+    AKV_VAULT_NAME: env.AKV_VAULT_NAME,
     AKV_URL: env.AKV_URL,
 }'

--- a/scripts/ccf/az-cleanroom-aci/down.sh
+++ b/scripts/ccf/az-cleanroom-aci/down.sh
@@ -21,7 +21,7 @@ az-cleanroom-aci-down() {
         --name ${DEPLOYMENT_NAME} \
         --provider-client "$DEPLOYMENT_NAME-provider" \
         --provider-config $WORKSPACE/providerConfig.json \
-        --delete-option delete-storage
+        --delete-option delete-storage || true
 
     az storage account delete --yes \
         --name "ccf$(cat $WORKSPACE/unique_string.txt)sa" \
@@ -40,8 +40,6 @@ az-cleanroom-aci-down() {
     unset KMS_MEMBER_PRIVK_PATH
 
     set +e
-
-    exit 0
 }
 
 az-cleanroom-aci-down "$@"

--- a/scripts/ccf/member/add.sh
+++ b/scripts/ccf/member/add.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+REPO_ROOT="$(realpath "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../../..")"
+
+ccf-member-add() {
+    set -e
+    source $REPO_ROOT/scripts/ccf/propose.sh
+
+    MEMBER_NAME=${MEMBER_NAME:-$1}
+    if [ -z "$MEMBER_NAME" ]; then
+        read -p "Enter member name: " MEMBER_NAME
+    fi
+    export MEMBER_NAME
+
+    # Hopefully we will have a single command for this eventually, e.g.
+    #   az cleanroom governance member up $MEMBER_NAME
+    # but for now:
+
+    if [[ $USE_AKV == false ]]; then
+        # Generate the member identity
+        (cd $WORKSPACE && az cleanroom governance member keygenerator-sh | bash -s -- --name $MEMBER_NAME)
+    else
+        # Create a key in AKV and download the cert for proposing
+        az keyvault certificate create \
+            --vault-name $AKV_VAULT_NAME \
+            --name $MEMBER_NAME-cert \
+            --policy "${AKV_POLICY:-$(az keyvault certificate get-default-policy)}"
+        az keyvault certificate download \
+            --vault-name $AKV_VAULT_NAME \
+            --name $MEMBER_NAME-cert \
+            --file $WORKSPACE/$MEMBER_NAME_cert.pem
+    fi
+
+    # Propose adding the member to the network
+    MEMBER_CERT=$(cat $WORKSPACE/$MEMBER_NAME_cert.pem) \
+        envsubst $REPO_ROOT/governance/proposals/set_member.json | jq \
+            > $WORKSPACE/proposals/set_member_${MEMBER_NAME}.json
+    ccf-propose $WORKSPACE/proposals/set_member_${MEMBER_NAME}.json
+
+    # Check if the proposal is accepted, otherwise early out with instructions to wait
+    # TODO: Implement
+
+    # Otherwise activate member
+    ccf-sign empty_file | \
+        curl $KMS_URL/gov/members/state-digests/${MEMBER_NAME}:update?api-version=2024-07-01 \
+            -X POST -s \
+            --cacert $KMS_SERVICE_CERT_PATH \
+            --cert $KMS_MEMBER_CERT_PATH \
+            --key $KMS_MEMBER_PRIVK_PATH \
+             | jq
+
+    # CLEANROOM BASED SOLUTION -------------------------------------------------
+
+    # # Ensure a governance client is running
+    # if ! az cleanroom governance client show; then
+    #     export CLEANROOM_GOV_CLIENT_NAME="$(curl -s -k $KMS_URL/gov/members | jq -r 'keys[0]')"
+    #     az cleanroom governance client deploy \
+    #         --ccf-endpoint $KMS_URL \
+    #         --service-cert $KMS_SERVICE_CERT_PATH \
+    #         --name $CLEANROOM_GOV_CLIENT_NAME \
+    #         --signing-cert $KMS_MEMBER_CERT_PATH \
+    #         --signing-key $KMS_MEMBER_PRIVK_PATH
+    # fi
+
+    # az cleanroom governance member add --certificate $WORKSPACE/${MEMBER_NAME}_cert.pem --identifier $MEMBER_NAME
+
+    # az cleanroom governance client deploy \
+    #     --ccf-endpoint $KMS_URL \
+    #     --service-cert $KMS_SERVICE_CERT_PATH \
+    #     --name $MEMBER_NAME \
+    #     --signing-cert $KMS_MEMBER_CERT_PATH \
+    #     --signing-key $KMS_MEMBER_PRIVK_PATH
+
+    set +e
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    ccf-member-add "$@"
+fi

--- a/scripts/ccf/propose.sh
+++ b/scripts/ccf/propose.sh
@@ -3,23 +3,69 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
+sign_proposal() {
+
+    proposal=$1
+
+    if [[ $USE_AKV == false ]]; then
+        ccf_cose_sign1 \
+            --content $proposal \
+            --signing-cert ${KMS_MEMBER_CERT_PATH} \
+            --signing-key ${KMS_MEMBER_PRIVK_PATH} \
+            --ccf-gov-msg-type proposal \
+            --ccf-gov-msg-created_at $(date -Is)
+    else
+        creation_time=$(date -u +"%Y-%m-%dT%H:%M:%S")
+        bearer_token=$( \
+            az account get-access-token \
+            --resource https://azure-key-management-akv.vault.azure.net \
+            --query accessToken --output tsv \
+        )
+        signature=$(mktemp)
+        ccf_cose_sign1_prepare \
+            --ccf-gov-msg-type proposal \
+            --ccf-gov-msg-created_at $creation_time \
+            --content $proposal \
+            --signing-cert ${KMS_MEMBER_CERT_PATH} | \
+            curl -X POST -s \
+                -H "Authorization: Bearer $bearer_token" \
+                -H "Content-Type: application/json" \
+                "${AKV_URL}/keys/${AKV_KEY_NAME}/sign?api-version=7.2" \
+                -d @- > $signature
+        ccf_cose_sign1_finish \
+            --ccf-gov-msg-type proposal \
+            --ccf-gov-msg-created_at $creation_time \
+            --content $proposal \
+            --signing-cert ${KMS_MEMBER_CERT_PATH} \
+            --signature $signature
+        rm -rf $signature
+    fi
+}
+
 ccf-propose() {
     set -e
 
-    echo "Proposing: $1"
+    proposal=$1
+    USE_AKV=${USE_AKV:-false}
+
+    echo "Proposing: $proposal"
     echo "  to $KMS_URL"
     echo "    cert: $KMS_SERVICE_CERT_PATH"
+
     echo "  as $KMS_MEMBER_CERT_PATH"
-    ccf_cose_sign1 \
-        --content $1 \
-        --signing-cert ${KMS_MEMBER_CERT_PATH} \
-        --signing-key ${KMS_MEMBER_PRIVK_PATH} \
-        --ccf-gov-msg-type proposal \
-        --ccf-gov-msg-created_at $(date -Is) \
-            | curl $KMS_URL/gov/proposals -k -H "Content-Type: application/cose" \
+    if [[ $USE_AKV == false ]]; then
+        echo "  using local key $KMS_MEMBER_PRIVK_PATH"
+    else
+        echo "  using AKV key $AKV_KEY_NAME from $AKV_NAME"
+    fi
+
+    sign_proposal $proposal \
+        | curl $KMS_URL/gov/proposals \
+            --cacert $KMS_SERVICE_CERT_PATH \
             --data-binary @- \
+            -H "Content-Type: application/cose" \
             -s \
-            --cacert $KMS_SERVICE_CERT_PATH -w '\n' \
+            -w '\n' \
                 | jq
 
     set +e

--- a/scripts/ccf/propose.sh
+++ b/scripts/ccf/propose.sh
@@ -56,7 +56,7 @@ ccf-propose() {
     if [[ $USE_AKV == false ]]; then
         echo "  using local key $KMS_MEMBER_PRIVK_PATH"
     else
-        echo "  using AKV key $AKV_KEY_NAME from $AKV_NAME"
+        echo "  using AKV key $AKV_KEY_NAME from $AKV_VAULT_NAME"
     fi
 
     sign_proposal $proposal \

--- a/scripts/ccf/propose.sh
+++ b/scripts/ccf/propose.sh
@@ -18,7 +18,7 @@ sign_proposal() {
         creation_time=$(date -u +"%Y-%m-%dT%H:%M:%S")
         bearer_token=$( \
             az account get-access-token \
-            --resource https://azure-key-management-akv.vault.azure.net \
+            --resource https://vault.azure.net \
             --query accessToken --output tsv \
         )
         signature=$(mktemp)

--- a/scripts/kms/constitution_set.sh
+++ b/scripts/kms/constitution_set.sh
@@ -10,7 +10,7 @@ constitution-set() {
   CONSTITUTION_PATH=$1
 
   # Get the current constitution
-  curl -k $KMS_URL/gov/service/constitution?api-version=2024-07-01 > $WORKSPACE/proposals/constitution.js
+  curl -s -k $KMS_URL/gov/service/constitution?api-version=2024-07-01 > $WORKSPACE/proposals/constitution.js
 
   # Append the consitution given
   cat "$CONSTITUTION_PATH" >> $WORKSPACE/proposals/constitution.js

--- a/test/system-test/conftest.py
+++ b/test/system-test/conftest.py
@@ -1,17 +1,19 @@
+import base64
+import hashlib
 import json
 import os
 import subprocess
-import pytest
-from utils import deploy_app_code
-import string
-import random
-import uuid
 import time
-import hashlib
-import base64
+import uuid
+
+import pytest
+
+from utils import deploy_app_code
 
 REPO_ROOT = os.path.realpath(os.path.join(os.path.dirname(__file__), "..", ".."))
 TEST_ENVIRONMENT = os.getenv("TEST_ENVIRONMENT", "ccf/sandbox_local")
+USE_AKV = os.getenv("USE_AKV", False)
+
 
 def unique_string():
     random_uuid = uuid.uuid4().bytes
@@ -27,78 +29,75 @@ def unique_string():
         .replace("_", "") \
         .lower()[:12]
 
-@pytest.fixture()
-def setup_kms():
 
-    deployment_name = os.getenv("DEPLOYMENT_NAME", f"kms-{unique_string()}")
-    use_akv = os.getenv("USE_AKV", False)
-
-    # Setup the CCF backend and set the environment accordingly
+def call_script(args, **kwargs):
+    res = subprocess.run(
+        args,
+        cwd=REPO_ROOT,
+        check=True,
+        stdout=subprocess.PIPE,
+        **kwargs,
+    ).stdout.decode()
+    print(res)
     try:
-        res = subprocess.run(
+        setup_vars = json.loads(res[res.rfind("{"):])
+        os.environ.update(setup_vars)
+    except json.JSONDecodeError:
+        ...
+
+
+@pytest.fixture(scope="session")
+def setup_jwt_issuer():
+    try:
+        call_script("./scripts/jwt_issuer/up.sh")
+        yield
+    finally:
+        call_script("./scripts/jwt_issuer/down.sh")
+
+
+@pytest.fixture(scope="session")
+def setup_akv():
+    akv_name = os.getenv("AKV_NAME", f"akv-{unique_string()}")
+    if USE_AKV:
+        try:
+            call_script(["./scripts/akv/up.sh", akv_name])
+            yield
+        finally:
+            call_script(
+                ["./scripts/akv/down.sh", akv_name],
+                stderr=subprocess.DEVNULL,
+            )
+
+
+@pytest.fixture()
+def setup_ccf():
+    deployment_name = os.getenv("DEPLOYMENT_NAME", f"kms-{unique_string()}")
+    try:
+        call_script(
             [f"scripts/{TEST_ENVIRONMENT}/up.sh", "--force-recreate"],
             env={
                 **os.environ,
                 "DEPLOYMENT_NAME": deployment_name,
             },
-            cwd=REPO_ROOT,
-            stdout=subprocess.PIPE,
-            check=True,
-        ).stdout.decode()
-        print(res)
-        setup_vars = json.loads(res[res.rfind("{"):])
-        os.environ.update(setup_vars)
-
-        res = subprocess.run(
-            ["make", "jwt-issuer-up"],
-            cwd=REPO_ROOT,
-            check=True,
-            stdout=subprocess.PIPE,
-        ).stdout.decode()
-        print(res)
-        setup_vars = json.loads(res[res.rfind("{"):])
-        os.environ.update(setup_vars)
-
-        if use_akv:
-            res = subprocess.run(
-                ["./scripts/akv/up.sh", f"{deployment_name}-akv"],
-                cwd=REPO_ROOT,
-                check=True,
-                stdout=subprocess.PIPE,
-            )
-            res = res.stdout.decode()
-            print(res)
-            setup_vars = json.loads(res[res.rfind("{"):])
-            os.environ.update(setup_vars)
-
-            res = subprocess.run(
-                ["./scripts/akv/key-import.sh", "private-key"],
-                cwd=REPO_ROOT,
-                check=True,
-                stdout=subprocess.PIPE,
-            ).stdout.decode()
-            print(res)
-            setup_vars = json.loads(res[res.rfind("{"):])
-            os.environ.update(setup_vars)
-
-        deploy_app_code()
-
+        )
         yield
 
     finally:
-        subprocess.run(
-            [f"scripts/{TEST_ENVIRONMENT}/down.sh", deployment_name],
+        call_script(
+            [f"scripts/{TEST_ENVIRONMENT}/down.sh"],
             env={
                 **os.environ,
                 "DEPLOYMENT_NAME": deployment_name,
             },
-            check=False,
         )
 
-        if use_akv:
-            res = subprocess.run(
-                ["./scripts/akv/down.sh", f"{deployment_name}-akv"],
-                cwd=REPO_ROOT,
-                check=True,
-                stderr=subprocess.DEVNULL,
-            )
+
+@pytest.fixture()
+def setup_kms(setup_ccf, setup_akv):
+    if USE_AKV:
+        call_script([
+            "./scripts/akv/key-import.sh",
+            f"{os.getenv("DEPLOYMENT_NAME", "kms")}-private-key"
+        ])
+    deploy_app_code()
+    yield

--- a/test/system-test/conftest.py
+++ b/test/system-test/conftest.py
@@ -57,7 +57,7 @@ def setup_jwt_issuer():
 
 @pytest.fixture(scope="session")
 def setup_akv():
-    akv_name = os.getenv("AKV_NAME", f"akv-{unique_string()}")
+    akv_name = os.getenv("AKV_VAULT_NAME", f"akv-{unique_string()}")
     if USE_AKV:
         try:
             call_script(["./scripts/akv/up.sh", akv_name])

--- a/test/system-test/conftest.py
+++ b/test/system-test/conftest.py
@@ -45,6 +45,7 @@ def setup_kms():
             stdout=subprocess.PIPE,
             check=True,
         ).stdout.decode()
+        print(res)
         setup_vars = json.loads(res[res.rfind("{"):])
         os.environ.update(setup_vars)
 
@@ -54,6 +55,7 @@ def setup_kms():
             check=True,
             stdout=subprocess.PIPE,
         ).stdout.decode()
+        print(res)
         setup_vars = json.loads(res[res.rfind("{"):])
         os.environ.update(setup_vars)
 
@@ -65,6 +67,7 @@ def setup_kms():
                 stdout=subprocess.PIPE,
             )
             res = res.stdout.decode()
+            print(res)
             setup_vars = json.loads(res[res.rfind("{"):])
             os.environ.update(setup_vars)
 
@@ -74,6 +77,7 @@ def setup_kms():
                 check=True,
                 stdout=subprocess.PIPE,
             ).stdout.decode()
+            print(res)
             setup_vars = json.loads(res[res.rfind("{"):])
             os.environ.update(setup_vars)
 

--- a/test/system-test/conftest.py
+++ b/test/system-test/conftest.py
@@ -97,7 +97,7 @@ def setup_kms(setup_ccf, setup_akv):
     if USE_AKV:
         call_script([
             "./scripts/akv/key-import.sh",
-            f"{os.getenv("DEPLOYMENT_NAME", "kms")}-private-key"
+            f'{os.getenv("DEPLOYMENT_NAME", "kms")}-private-key'
         ])
     deploy_app_code()
     yield

--- a/test/system-test/conftest.py
+++ b/test/system-test/conftest.py
@@ -67,6 +67,8 @@ def setup_akv():
                 ["./scripts/akv/down.sh", akv_name],
                 stderr=subprocess.DEVNULL,
             )
+    else:
+        yield
 
 
 @pytest.fixture()

--- a/test/system-test/endpoints.py
+++ b/test/system-test/endpoints.py
@@ -17,6 +17,10 @@ def call_endpoint(endpoint, **kwargs):
         stdout=subprocess.PIPE,
     ).stdout.decode().splitlines()
 
+    print(f'Called "{" ".join(command)}"')
+    print(f"Response Code: {status_code}")
+    print(f"Response Body: {json.loads("".join(response) or '{}')}")
+
     return (
         int(status_code),
         json.loads("".join(response) or '{}'),

--- a/test/system-test/endpoints.py
+++ b/test/system-test/endpoints.py
@@ -19,7 +19,7 @@ def call_endpoint(endpoint, **kwargs):
 
     print(f'Called "{" ".join(command)}"')
     print(f"Response Code: {status_code}")
-    print(f"Response Body: {json.loads("".join(response) or '{}')}")
+    print(f'Response Body: {json.loads("".join(response) or "{}")}')
 
     return (
         int(status_code),

--- a/test/system-test/test_key.py
+++ b/test/system-test/test_key.py
@@ -47,7 +47,7 @@ def test_with_keys_and_policy(setup_kms):
     assert key_json["wrapped"] == ""
 
 
-def test_with_keys_and_policy_jwt_auth(setup_kms):
+def test_with_keys_and_policy_jwt_auth(setup_kms, setup_jwt_issuer):
     apply_kms_constitution()
     apply_key_release_policy()
     trust_jwt_issuer()


### PR DESCRIPTION
### Motivation

In order to test azure-cleanroom based CCF networks, we want to have testing with as representative systems as possible. Production systems will store member identities in something like AKV rather than locally, so we want test coverage of this

### Changes 
- [x] Add lifecycle scripts to bring AKVs up and down 211127541e24d9c39db1919fe82a80ded415a72e
- [x] Update propose.sh to allow using AKV keys bd9e3e1d1ca2bcaf9e0b64e0d1d3bbf2ba13281f
- [x] Add ability to run tests using an AKV key 6b866ddb9aa843987bcb4ad14c6708736ae75fb4
- [x] Add tests using AKV keys 9f4ea4cdbad67dd501fae2e039d99a5830bcfb75
- [x] Update cleanup job to cleanup AKVs that failed to be deleted during runs 293ac8f5de1ea1f33d1699618ca48c647f5525d3