### PR TITLE
Fix waiting for 200 loop. Could cause infinitive loop

### DIFF
--- a/test/e2e-test/src/index.ts
+++ b/test/e2e-test/src/index.ts
@@ -266,7 +266,7 @@ class Demo {
       } else if (statusCode !== 200) {
         throw new Error(`🛑 [TEST FAILURE]: Expected ${statusCode} to be 200`);
       }
-    } while (statusCode !== 200);
+    } while (statusCode == 202);
 
     // Test with JWT
     console.log(`📝 Get wrapped key with JWT...`);


### PR DESCRIPTION
I've noticed some occurrences of e2e CI getting timed out in fetching the key.
Improved the loop waiting for 200 after 202 to prevent an infinite loop.