### PR TITLE
Remove globally trusting az cleanroom cert

### DIFF
--- a/scripts/ccf/az-cleanroom-aci/up.sh
+++ b/scripts/ccf/az-cleanroom-aci/up.sh
@@ -40,9 +40,6 @@ az-cleanroom-aci-up() {
     export KMS_MEMBER_CERT_PATH="$WORKSPACE/ccf-operator_cert.pem"
     export KMS_MEMBER_PRIVK_PATH="$WORKSPACE/ccf-operator_privk.pem"
 
-    sudo cp $KMS_SERVICE_CERT_PATH /usr/local/share/ca-certificates/kms_ca.crt
-    sudo update-ca-certificates
-
     set +e
 }
 


### PR DESCRIPTION
### Motivation
`az-cleanroom-aci/up.sh` globally trusts the CCF networks service certificate as pointed out in the review of #259. 

This means we wouldn't need to provide the service cert to our HTTP requests, however if a CCF network was deployed separately, it's simpler to just provide the service cert rather than updating the system to globally trust it. Global trusting also provides the opportunity to step on existing certs breaking requests to that service.

For those reasons I think it's better to explicitly state the service cert in each request, making globally trusting it here redundant.

### Changes
- [x] Drop the lines which globally trust the service cert in the az-cleanroom case