### PR TITLE
Allow running concurrent JWT issuers

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -35,3 +35,27 @@ jobs:
     uses: ./.github/workflows/system-test.yml
     with:
       test: ${{ matrix.test }}
+
+  jwt-issuer-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log into Azure
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.MANAGED_ID_CLIENT_ID }}
+          tenant-id: ${{ secrets.MANAGED_ID_TENANT_ID }}
+          subscription-id: 7ca35580-fc67-469c-91a7-68b38569ca6e
+
+      - name: Install Dependencies
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: ./scripts/tools/install-deps.sh
+
+      - name: Run System Tests
+        env:
+          TEST_ENVIRONMENT: ccf/az-cleanroom-aci
+        run: |
+          ./scripts/jwt_issuer_up.sh

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -35,27 +35,3 @@ jobs:
     uses: ./.github/workflows/system-test.yml
     with:
       test: ${{ matrix.test }}
-
-  jwt-issuer-test:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Log into Azure
-        uses: azure/login@v2
-        with:
-          client-id: ${{ secrets.MANAGED_ID_CLIENT_ID }}
-          tenant-id: ${{ secrets.MANAGED_ID_TENANT_ID }}
-          subscription-id: 7ca35580-fc67-469c-91a7-68b38569ca6e
-
-      - name: Install Dependencies
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: ./scripts/tools/install-deps.sh
-
-      - name: Run System Tests
-        env:
-          TEST_ENVIRONMENT: ccf/az-cleanroom-aci
-        run: |
-          ./scripts/jwt_issuer/up.sh

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -58,4 +58,4 @@ jobs:
         env:
           TEST_ENVIRONMENT: ccf/az-cleanroom-aci
         run: |
-          ./scripts/jwt_issuer_up.sh
+          ./scripts/jwt_issuer/up.sh

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ package-lock.json
 vol
 .venv_ccf_sandbox
 workspace*
-jwt_issuer_workspace*
+jwt_issuers_workspace*
 .env
 hello/
 ccf-app/

--- a/Makefile
+++ b/Makefile
@@ -56,12 +56,12 @@ stop-all: stop-host stop-idp # Stop all services
 # idp commands to issue JWT
 start-idp:  ## 🏃 Start the idp for testing jwt
 	@echo -e "\e[34m$@\e[0m" || true
-	source ./scripts/jwt_issuer/up.sh
+	source ./scripts/jwt_issuer/up.sh --build
 
 # Start hosting the application using `sandbox.sh` and enable custom JWT authentication
 start-host: stop-host  ## 🏃 Start the CCF network using Sandbox.sh
 	@echo -e "\e[34m$@\e[0m" || true
-	MEMBER_COUNT=${MEMBER_COUNT} source ./scripts/ccf/sandbox_local/up.sh && \
+	MEMBER_COUNT=${MEMBER_COUNT} source ./scripts/ccf/sandbox_local/up.sh --build && \
 	source ./scripts/kms/js_app_set.sh && \
 	source ./scripts/kms/constitution_set.sh \
 		--resolve ./governance/constitution/resolve/auto_accept.js \
@@ -70,8 +70,8 @@ start-host: stop-host  ## 🏃 Start the CCF network using Sandbox.sh
 start-host-idp: stop-host stop-idp build ## 🏃 Start the CCF network && idp using Sandbox.sh
 	@echo -e "\e[34m$@\e[0m" || true
 	@echo "Executing: $(COMMAND)"
-	MEMBER_COUNT=${MEMBER_COUNT} source ./scripts/ccf/sandbox_local/up.sh && \
-	source ./scripts/jwt_issuer/up.sh && \
+	MEMBER_COUNT=${MEMBER_COUNT} source ./scripts/ccf/sandbox_local/up.sh --build && \
+	source ./scripts/jwt_issuer/up.sh --build && \
 	source ./scripts/kms/constitution_set.sh \
 		--resolve ./governance/constitution/resolve/auto_accept.js \
 		--actions ./governance/constitution/actions/kms.js && \

--- a/README.md
+++ b/README.md
@@ -217,7 +217,6 @@ make start-host-idp
 ### Test identity provier in seperate terminal
 
 ```
-export AadEndpoint=http://localhost:3000/token
 ./scripts/generate_access_token.sh
 ```
 

--- a/scripts/generate_access_token.sh
+++ b/scripts/generate_access_token.sh
@@ -27,7 +27,7 @@ if [ -f aad.env ]; then
   source aad.env
 fi
 
-curl -X POST ${AadEndpoint:-http://localhost:3000/token} \
+curl -X POST ${AadEndpoint:-$(cat jwt_issuers_workspace/default/jwt_issuer_address)/token} \
     -H "Content-Type: application/x-www-form-urlencoded" \
     -d "client_id=${ClientApplicationId:-}&client_secret=${ClientSecret:-}&scope=${ApiIdentifierUri:-}/.default&grant_type=client_credentials" \
     -w "\n"

--- a/scripts/jwt_issuer/down.sh
+++ b/scripts/jwt_issuer/down.sh
@@ -7,5 +7,5 @@ set -e
 
 docker compose -p ${UNIQUE_ID:-default} -f services/docker-compose.yml down jwt-issuer --remove-orphans
 
+unset JWT_ISSUER_WORKSPACE
 unset JWT_ISSUER
-unset JWT_TOKEN_ISSUER_URL

--- a/scripts/jwt_issuer/down.sh
+++ b/scripts/jwt_issuer/down.sh
@@ -5,4 +5,7 @@
 
 set -e
 
-docker compose -f services/docker-compose.yml down jwt-issuer --remove-orphans
+docker compose -p ${UNIQUE_ID-:services} -f services/docker-compose.yml down jwt-issuer --remove-orphans
+
+unset JWT_ISSUER
+unset JWT_TOKEN_ISSUER_URL

--- a/scripts/jwt_issuer/down.sh
+++ b/scripts/jwt_issuer/down.sh
@@ -5,7 +5,7 @@
 
 set -e
 
-docker compose -p ${UNIQUE_ID-:services} -f services/docker-compose.yml down jwt-issuer --remove-orphans
+docker compose -p ${UNIQUE_ID:-default} -f services/docker-compose.yml down jwt-issuer --remove-orphans
 
 unset JWT_ISSUER
 unset JWT_TOKEN_ISSUER_URL

--- a/scripts/jwt_issuer/up.sh
+++ b/scripts/jwt_issuer/up.sh
@@ -7,10 +7,10 @@ jwt-issuer-up() {
     set -e
 
     REPO_ROOT="$(realpath "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../..")"
-    export JWT_ISSUER_WORKSPACE=$(realpath ${JWT_ISSUER_WORKSPACE:-$REPO_ROOT/jwt_issuer_workspace_${UNIQUE_ID:-services}})
+    export JWT_ISSUER_WORKSPACE=$(realpath ${JWT_ISSUER_WORKSPACE:-$REPO_ROOT/jwt_issuers_workspace/${UNIQUE_ID:-default}/})
     mkdir -p $JWT_ISSUER_WORKSPACE
 
-    docker compose -p ${UNIQUE_ID:-services} -f services/docker-compose.yml up jwt-issuer --wait "$@"
+    docker compose -p ${UNIQUE_ID:-default} -f services/docker-compose.yml up jwt-issuer --wait "$@"
     sudo chown $USER:$USER -R $JWT_ISSUER_WORKSPACE
 
     export JWT_ISSUER="$(cat $JWT_ISSUER_WORKSPACE/jwt_issuer_address)/token"

--- a/scripts/jwt_issuer/up.sh
+++ b/scripts/jwt_issuer/up.sh
@@ -18,7 +18,7 @@ jwt-issuer-up() {
     set +e
 }
 
-jwt-issuer-up
+jwt-issuer-up "$@"
 
 jq -n '{
     JWT_ISSUER_WORKSPACE: env.JWT_ISSUER_WORKSPACE,

--- a/scripts/jwt_issuer/up.sh
+++ b/scripts/jwt_issuer/up.sh
@@ -7,14 +7,13 @@ jwt-issuer-up() {
     set -e
 
     REPO_ROOT="$(realpath "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../..")"
-    export JWT_ISSUER_WORKSPACE=$(realpath ${JWT_ISSUER_WORKSPACE:-$REPO_ROOT/jwt_issuer_workspace})
+    export JWT_ISSUER_WORKSPACE=$(realpath ${JWT_ISSUER_WORKSPACE:-$REPO_ROOT/jwt_issuer_workspace_${UNIQUE_ID:-services}})
     mkdir -p $JWT_ISSUER_WORKSPACE
 
-    docker compose -f services/docker-compose.yml up jwt-issuer --wait
-
+    docker compose -p ${UNIQUE_ID-:services} -f services/docker-compose.yml up jwt-issuer --wait "$@"
     sudo chown $USER:$USER -R $JWT_ISSUER_WORKSPACE
 
-    export JWT_ISSUER="http://localhost:3000/token"
+    export JWT_ISSUER="$(cat $JWT_ISSUER_WORKSPACE/jwt_issuer_address)/token"
 
     set +e
 }

--- a/scripts/jwt_issuer/up.sh
+++ b/scripts/jwt_issuer/up.sh
@@ -10,7 +10,7 @@ jwt-issuer-up() {
     export JWT_ISSUER_WORKSPACE=$(realpath ${JWT_ISSUER_WORKSPACE:-$REPO_ROOT/jwt_issuer_workspace_${UNIQUE_ID:-services}})
     mkdir -p $JWT_ISSUER_WORKSPACE
 
-    docker compose -p ${UNIQUE_ID-:services} -f services/docker-compose.yml up jwt-issuer --wait "$@"
+    docker compose -p ${UNIQUE_ID:-services} -f services/docker-compose.yml up jwt-issuer --wait "$@"
     sudo chown $USER:$USER -R $JWT_ISSUER_WORKSPACE
 
     export JWT_ISSUER="$(cat $JWT_ISSUER_WORKSPACE/jwt_issuer_address)/token"

--- a/scripts/jwt_issuer/up.sh
+++ b/scripts/jwt_issuer/up.sh
@@ -7,7 +7,7 @@ jwt-issuer-up() {
     set -e
 
     REPO_ROOT="$(realpath "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../..")"
-    export JWT_ISSUER_WORKSPACE=$(realpath ${JWT_ISSUER_WORKSPACE:-$REPO_ROOT/jwt_issuers_workspace/${UNIQUE_ID:-default}/})
+    export JWT_ISSUER_WORKSPACE=${JWT_ISSUER_WORKSPACE:-$REPO_ROOT/jwt_issuers_workspace/${UNIQUE_ID:-default}/}
     mkdir -p $JWT_ISSUER_WORKSPACE
 
     docker compose -p ${UNIQUE_ID:-default} -f services/docker-compose.yml up jwt-issuer --wait "$@"

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -24,4 +24,4 @@ services:
       interval: 1s
       retries: 120
     volumes:
-      - ${JWT_ISSUER_WORKSPACE:-../jwt_issuer_workspace}:/workspace
+      - ${JWT_ISSUER_WORKSPACE:-../jwt_issuers_workspace/default}:/workspace

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -20,17 +20,8 @@ services:
     environment:
       - KMS_WORKSPACE=/workspace
     healthcheck:
-      test:
-        [
-          "CMD",
-          "curl",
-          "-k",
-          "--fail",
-          "-X",
-          "POST",
-          "http://localhost:3000/token",
-        ]
+      test: "curl -k --fail -X POST $(cat /workspace/jwt_issuer_address)/token"
       interval: 1s
       retries: 120
     volumes:
-      - ${JWT_ISSUER_WORKSPACE:-./}:/workspace
+      - ${JWT_ISSUER_WORKSPACE:-../jwt_issuer_workspace}:/workspace

--- a/test/system-test/conftest.py
+++ b/test/system-test/conftest.py
@@ -29,6 +29,8 @@ def unique_string():
         .replace("_", "") \
         .lower()[:12]
 
+os.environ["UNIQUE_ID"] = unique_string()
+
 
 def call_script(args, **kwargs):
     res = subprocess.run(

--- a/test/system-test/conftest.py
+++ b/test/system-test/conftest.py
@@ -48,7 +48,7 @@ def call_script(args, **kwargs):
         ...
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture()
 def setup_jwt_issuer():
     try:
         call_script(

--- a/test/system-test/conftest.py
+++ b/test/system-test/conftest.py
@@ -52,7 +52,7 @@ def call_script(args, **kwargs):
 def setup_jwt_issuer():
     try:
         call_script(
-            "./scripts/jwt_issuer/up.sh",
+            ["./scripts/jwt_issuer/up.sh", "--build"],
             env={
                 **os.environ,
                 "JWT_ISSUER_WORKSPACE": f"{REPO_ROOT}/jwt_issuer_workspace",

--- a/test/utils/jwt/src/index.ts
+++ b/test/utils/jwt/src/index.ts
@@ -12,8 +12,7 @@ const proposalsPath = `${process.env.KMS_WORKSPACE}/proposals`;
 const privateKeyPath = `${process.env.KMS_WORKSPACE}/private.pem`;
 const certificatePath = `${process.env.KMS_WORKSPACE}/cert.pem`;
 const kid = "Demo IDP kid";
-const hostPort = 3000;
-const host = `http://localhost:${hostPort}`;
+const host = `http://localhost:0`;
 const iss = "http://Demo-jwt-issuer";
 const sub = "c0d8e9a7-6b8e-4e1f-9e4a-3b2c1d0f5a6b";
 const name = "Cool caller";
@@ -85,6 +84,14 @@ app.get("/keys", (req: Request, res: Response) => {
   res.send({ keys: [jwk] });
 });
 
-app.listen(hostPort, () =>
-  console.log(`JWT Issuer started on port ${hostPort}`),
-);
+const server = app.listen(0, () => {
+  const addressInfo = server.address();
+  if (addressInfo && typeof addressInfo !== "string") {
+    const { port } = addressInfo;
+    fs.writeFileSync(
+      `${process.env.KMS_WORKSPACE}/jwt_issuer_address`,
+      `http://localhost:${port}`
+    );
+    console.log(`JWT Issuer started on http://localhost:${port}`);
+  }
+});


### PR DESCRIPTION
### Motivation

If we want to run multiple concurrent JWT issuers for testing in #260 we need to be able to have separate instances of the test JWT issuer run at once

### Changes
- [x] Define a `UNIQUE_ID` environment variable to delimit iss
- [x] Scope docker compose invocations for JWT issuer to a project name based on `UNIQUE_ID`
- [x] Update test JWT issuer implementation to bind to a random available port and emit the address in a file