### PR TITLE
Roll back to ubuntu 22.04

### DIFF
--- a/.github/workflows/system-test.yml
+++ b/.github/workflows/system-test.yml
@@ -18,7 +18,7 @@ jobs:
 
   test:
     name: ${{ inputs.test }} (${{ matrix.config.env }}) (${{ matrix.config.use_akv && 'akv' || 'local' }}_keys)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Looks like the CI fails consistently since using ubuntu 24.04, so rolling back to 22.04 to see if it improves things