### PR TITLE
Fix retry mechanism in az cleanroom CCF network up

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
   workflow_dispatch:
   schedule:
     - cron: "0 1 * * *"

--- a/.github/workflows/system-test.yml
+++ b/.github/workflows/system-test.yml
@@ -18,7 +18,7 @@ jobs:
 
   test:
     name: ${{ inputs.test }} (${{ matrix.config.env }}) (${{ matrix.config.use_akv && 'akv' || 'local' }}_keys)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/scripts/ccf/az-cleanroom-aci/up.sh
+++ b/scripts/ccf/az-cleanroom-aci/up.sh
@@ -27,6 +27,7 @@ az-cleanroom-aci-up() {
 
     retries=10
     ccf_up=false
+    set +e
     while [ $ccf_up = false ] && [ $retries -gt 0 ]; do
         az cleanroom ccf network up \
             --subscription $SUBSCRIPTION \
@@ -39,6 +40,7 @@ az-cleanroom-aci-up() {
         fi
         retries=$((retries - 1))
     done
+    set -e
 
     export KMS_URL=`az-cleanroom-aci-get-url`
 
@@ -47,7 +49,7 @@ az-cleanroom-aci-up() {
     export KMS_MEMBER_PRIVK_PATH="$WORKSPACE/ccf-operator_privk.pem"
 
     mkdir -p $WORKSPACE/proposals
-    
+
     set +e
 }
 

--- a/scripts/ccf/az-cleanroom-aci/up.sh
+++ b/scripts/ccf/az-cleanroom-aci/up.sh
@@ -27,13 +27,17 @@ az-cleanroom-aci-up() {
 
     retries=10
     ccf_up=false
+    success=false
     set +e
-    while [ $ccf_up = false ] && [ $retries -gt 0 ]; do
+    while [ $ccf_up = false ] && [ $success = false ] && [ $retries -gt 0 ]; do
         az cleanroom ccf network up \
             --subscription $SUBSCRIPTION \
             --resource-group $RESOURCE_GROUP \
             --provider-client "$DEPLOYMENT_NAME-provider" \
             --name $DEPLOYMENT_NAME
+        if [ $? -eq 0 ]; then
+            success=true
+        fi
         kms_url=`az-cleanroom-aci-get-url`
         if curl -k $kms_url/node/network -o /dev/null -s -w "%{http_code}" | grep -q 200; then
             ccf_up=true
@@ -41,6 +45,10 @@ az-cleanroom-aci-up() {
         retries=$((retries - 1))
     done
     set -e
+
+    if [ $success = false ] || [ $ccf_up = false ]; then
+        exit 1
+    fi
 
     export KMS_URL=`az-cleanroom-aci-get-url`
 


### PR DESCRIPTION
The up.sh script is set to fail fast which means the retry mechanism won't behave as expected
We also don't check that the az cli command fully completes which can lead to a network being up, but not fully configured