### PR TITLE
Use ts-node to run e2e tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
   workflow_dispatch:
   schedule:
     - cron: "0 1 * * *"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "bundle": "node build_bundle.js dist",
     "build-proto": "buf generate src/endpoints/proto",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
-    "e2e-test": "node --import 'data:text/javascript,import { register } from \"node:module\"; import { pathToFileURL } from \"node:url\"; register(\"./loader-register.js\", pathToFileURL(\"./\"));' ./test/e2e-test/src/index.ts"
+    "e2e-test": "node --loader ts-node/esm ./test/e2e-test/src/index.ts"
   },
   "type": "module",
   "engines": {


### PR DESCRIPTION
### Motivation

The errors we see intermittently in the e2e tests have this message
```
Error: or [Error]: Unknown file extension ".ts" for /workspaces/azure-privacy-sandbox-kms/test/e2e-test/src/index.ts
```

It appears that the current method of running typescript files directly with node is very error prone, so using ts-node instead