### PR TITLE
Allow setting of JWT Issuer port

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -50,4 +50,38 @@ WORKDIR /kms
 ARG CCF_PLATFORM
 ENV CCF_PLATFORM=${CCF_PLATFORM}
 ENV JWT_ISSUER_PORT=3000
-CMD ["/bin/bash", "-c", "mkdir -p workspace && (cd test/utils/jwt && KMS_WORKSPACE=/kms/workspace nohup npm run start > nohup.out 2>&1 &) && ./scripts/wait_idp_ready.sh && ./scripts/set_python_env.sh && npm install && npm run build && env -i PATH=${PATH} KMS_WORKSPACE=workspace /opt/ccf_${CCF_PLATFORM}/bin/sandbox.sh --js-app-bundle ./dist/ --initial-member-count 3 --initial-user-count 1 --constitution ./governance/constitution/actions/kms.js --jwt-issuer workspace/proposals/set_jwt_issuer_test_sandbox.json  -v --http2 & (./scripts/kms_wait.sh && make setup && tail -f /kms/workspace/sandbox_0/out)"]
+CMD /bin/bash -c ' \
+    mkdir -p workspace; \
+    mkdir -p workspace/proposals; \
+    \
+    (cd test/utils/jwt && KMS_WORKSPACE=/kms/workspace nohup npm run start > nohup.out 2>&1 &); \
+    ./scripts/wait_idp_ready.sh; \
+    export JWK=$( \
+        npx pem-jwk "./workspace/private.pem" \
+            | jq --arg cert "$(cat ./workspace/cert.pem)" \
+                '\''{kty, n, e} + {x5c: [$cert]} + {kid: "Demo IDP kid"}'\'' \
+    ); \
+    echo "\
+    { \
+        \"issuer\": \"http://Demo-jwt-issuer\", \
+        \"jwks\": { \
+            \"keys\": [ \
+                $JWK \
+            ] \
+        } \
+    }" | jq > ./workspace/proposals/set_jwt_issuer.json; \
+    ./scripts/set_python_env.sh; \
+    npm install; \
+    npm run build; \
+    env -i PATH=${PATH} KMS_WORKSPACE=workspace \
+        /opt/ccf_${CCF_PLATFORM}/bin/sandbox.sh \
+            --js-app-bundle ./dist/ \
+            --initial-member-count 3 \
+            --initial-user-count 1 \
+            --constitution ./governance/constitution/actions/kms.js \
+            --jwt-issuer workspace/proposals/set_jwt_issuer.json \
+            -v --http2 & \
+    ./scripts/kms_wait.sh; \
+    make setup; \
+    tail -f /kms/workspace/sandbox_0/out; \
+'

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -49,4 +49,5 @@ WORKDIR /kms
 
 ARG CCF_PLATFORM
 ENV CCF_PLATFORM=${CCF_PLATFORM}
+ENV JWT_ISSUER_PORT=3000
 CMD ["/bin/bash", "-c", "mkdir -p workspace && (cd test/utils/jwt && KMS_WORKSPACE=/kms/workspace nohup npm run start > nohup.out 2>&1 &) && ./scripts/wait_idp_ready.sh && ./scripts/set_python_env.sh && npm install && npm run build && env -i PATH=${PATH} KMS_WORKSPACE=workspace /opt/ccf_${CCF_PLATFORM}/bin/sandbox.sh --js-app-bundle ./dist/ --initial-member-count 3 --initial-user-count 1 --constitution ./governance/constitution/actions/kms.js --jwt-issuer workspace/proposals/set_jwt_issuer_test_sandbox.json  -v --http2 & (./scripts/kms_wait.sh && make setup && tail -f /kms/workspace/sandbox_0/out)"]

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -19,6 +19,7 @@ services:
     network_mode: host
     environment:
       - KMS_WORKSPACE=/workspace
+      - JWT_ISSUER_PORT=${JWT_ISSUER_PORT:-}
     healthcheck:
       test: "curl -k --fail -X POST $(cat /workspace/jwt_issuer_address)/token"
       interval: 1s

--- a/test/utils/jwt/src/index.ts
+++ b/test/utils/jwt/src/index.ts
@@ -61,7 +61,8 @@ app.get("/keys", (req: Request, res: Response) => {
   res.send({ keys: [jwk] });
 });
 
-const server = app.listen(0, () => {
+const port = process.env.JWT_ISSUER_PORT || 0;
+const server = app.listen(port, () => {
   const addressInfo = server.address();
   if (addressInfo && typeof addressInfo !== "string") {
     const { port } = addressInfo;


### PR DESCRIPTION
### Motivation

Since #266, the test JWT issuer doesn't use a fixed port, privacy-sandbox-dev assumes it does which breaks it's testing.
To fix this the options are to either:

- Allow setting the port of the JWT issuer to the port assumed by privacy-sandbox-dev
- Read the full address in privacy-sandbox-dev

Since privacy-sandbox-dev assumes the port in many places (including in an instance running in ACI) it's non-trivial to do the first change, so opting for the latter.

### Changes

- [x] Update test JWT Issuer implementation to use the value of JWT_ISSUER_PORT as the port if set (default to 0 if unset)
- [x] Pass that env variable into the JWT issuer container image in docker compose
- [x] Set that value to 3000 for the standalone image used by privacy-sandbox-dev