### PR TITLE
Use ubuntu 24.04 (latest) for system-test CI

### DIFF
--- a/.github/workflows/system-test.yml
+++ b/.github/workflows/system-test.yml
@@ -18,7 +18,7 @@ jobs:
 
   test:
     name: ${{ inputs.test }} (${{ matrix.config.env }}) (${{ matrix.config.use_akv && 'akv' || 'local' }}_keys)
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/system-test.yml
+++ b/.github/workflows/system-test.yml
@@ -51,6 +51,17 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: ./scripts/tools/install-deps.sh
+      
+      - name: Log into Azure
+        uses: azure/login@v2
+        with:
+          # Use a managed identity to authenticate to Azure
+          # Use properties such as client-id, tenant-id, and subscription-id in the secrets and vars
+          # The managed identity should have a federated credential with subject identiier repo:<organization>/<repo>:pull_request
+          # Use subject identifier repo:<organization>/<repo>:ref:refs/heads/<branch> for running manual CI's
+          client-id: ${{ secrets.MANAGED_ID_CLIENT_ID }}
+          tenant-id: ${{ secrets.MANAGED_ID_TENANT_ID }}
+          subscription-id: 7ca35580-fc67-469c-91a7-68b38569ca6e
 
       - name: Run System Tests
         env:

--- a/.github/workflows/system-test.yml
+++ b/.github/workflows/system-test.yml
@@ -36,17 +36,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Log into Azure
-        uses: azure/login@v2
-        with:
-          # Use a managed identity to authenticate to Azure
-          # Use properties such as client-id, tenant-id, and subscription-id in the secrets and vars
-          # The managed identity should have a federated credential with subject identiier repo:<organization>/<repo>:pull_request
-          # Use subject identifier repo:<organization>/<repo>:ref:refs/heads/<branch> for running manual CI's
-          client-id: ${{ secrets.MANAGED_ID_CLIENT_ID }}
-          tenant-id: ${{ secrets.MANAGED_ID_TENANT_ID }}
-          subscription-id: 7ca35580-fc67-469c-91a7-68b38569ca6e
-
       - name: Install Dependencies
         env:
           GH_TOKEN: ${{ github.token }}

--- a/scripts/tools/install-deps.sh
+++ b/scripts/tools/install-deps.sh
@@ -7,7 +7,7 @@ REPO_ROOT="$(realpath "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../..")"
 set -x
 
 date
-pip install -q -r $REPO_ROOT/requirements.txt -vvv
+pip install -q -r $REPO_ROOT/requirements.txt -v
 date
 npm install --silent --prefix $REPO_ROOT/ --dd
 date

--- a/scripts/tools/install-deps.sh
+++ b/scripts/tools/install-deps.sh
@@ -6,9 +6,6 @@ REPO_ROOT="$(realpath "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../..")"
 
 set -x
 
-date
-pip install -q -r $REPO_ROOT/requirements.txt -v
-date
-npm install --silent --prefix $REPO_ROOT/ --dd
-date
+pip install -q -r $REPO_ROOT/requirements.txt
+npm install --silent --prefix $REPO_ROOT/
 $REPO_ROOT/scripts/tools/install-c-aci-testing.sh > /dev/null

--- a/scripts/tools/install-deps.sh
+++ b/scripts/tools/install-deps.sh
@@ -6,6 +6,9 @@ REPO_ROOT="$(realpath "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../..")"
 
 set -x
 
-pip install -q -r $REPO_ROOT/requirements.txt
-npm install --silent --prefix $REPO_ROOT/
+date
+pip install -q -r $REPO_ROOT/requirements.txt -vvv
+date
+npm install --silent --prefix $REPO_ROOT/ --dd
+date
 $REPO_ROOT/scripts/tools/install-c-aci-testing.sh > /dev/null


### PR DESCRIPTION
To handle issue https://github.com/microsoft/azure-privacy-sandbox-kms/issues/278.
The problem reproduces in local containers too not only in github actions runner. ubuntu 24.04 struggles to run `pip install` even locally (it took around 10 minutes while it's 1 min with 20.04). It seems to be panda library which is especially slow.

The error in the CI is just token expiration, so I moved the login step just before it's required.