### PR TITLE
Force CCF container base image versions

### DIFF
--- a/services/ccf-sandbox/Dockerfile
+++ b/services/ccf-sandbox/Dockerfile
@@ -1,5 +1,5 @@
 ARG CCF_PLATFORM
-FROM ghcr.io/microsoft/ccf/app/dev/${CCF_PLATFORM}:latest
+FROM ghcr.io/microsoft/ccf/app/dev/${CCF_PLATFORM}:ccf-5.0.11
 
 # Pre install CCF dependencies to speed up container start (only works in virtual mode)
 ARG CCF_PLATFORM

--- a/services/ccf-sandbox/docker-compose.yml
+++ b/services/ccf-sandbox/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   ccf-sandbox:
-    image: azurekms.azurecr.io/ccf_sandbox/${CCF_PLATFORM:-virtual}:latest
+    image: azurekms.azurecr.io/ccf_sandbox/${CCF_PLATFORM:-virtual}:ccf-5.0.11
     build:
       context: .
       dockerfile: Dockerfile
@@ -9,7 +9,7 @@ services:
     command: |
       /bin/bash -c '
         echo "sandbox_0" > /node_id &&
-        mkdir -p /workspace/sandbox_0/ && touch /workspace/sandbox_0/out && tail -f /workspace/sandbox_0/out & 
+        mkdir -p /workspace/sandbox_0/ && touch /workspace/sandbox_0/out && tail -f /workspace/sandbox_0/out &
         /opt/ccf_${CCF_PLATFORM:-virtual}/bin/sandbox.sh --http2 --initial-member-count ${MEMBER_COUNT:-1}
       '
     network_mode: host

--- a/services/docker-compose.yml
+++ b/services/docker-compose.yml
@@ -1,12 +1,12 @@
 services:
   ccf-sandbox:
-    image: azurekms.azurecr.io/ccf_sandbox/${CCF_PLATFORM:-virtual}:latest
+    image: azurekms.azurecr.io/ccf_sandbox/${CCF_PLATFORM:-virtual}:ccf-5.0.11
     extends:
       file: ./ccf-sandbox/docker-compose.yml
       service: ccf-sandbox
 
   ccf-sandbox-joiner:
-    image: azurekms.azurecr.io/ccf_sandbox/${CCF_PLATFORM:-virtual}:latest
+    image: azurekms.azurecr.io/ccf_sandbox/${CCF_PLATFORM:-virtual}:ccf-5.0.11
     extends:
       file: ./ccf-sandbox/docker-compose.yml
       service: ccf-sandbox-joiner


### PR DESCRIPTION
The CCF containers use the latest version and  an update this week broke our CCF. This fixes the versions for the containers used in our containers