### PR TITLE
Add a set of tests which are run on single KMS instance

### DIFF
--- a/.github/workflows/system-test.yml
+++ b/.github/workflows/system-test.yml
@@ -25,13 +25,10 @@ jobs:
         config:
           - env: sandbox_local
             use_akv: false
-            threads: 1
           - env: sandbox_local
             use_akv: true
-            threads: 1
           - env: az-cleanroom-aci
             use_akv: false
-            threads: auto
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -40,7 +37,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: ./scripts/tools/install-deps.sh
-      
+
       - name: Log into Azure
         uses: azure/login@v2
         with:
@@ -58,5 +55,4 @@ jobs:
           USE_AKV: ${{ matrix.config.use_akv }}
         run: |
           pytest -sv \
-            test/system-test/test_${{ inputs.test }}.py \
-            -n ${{ matrix.config.threads }}
+            test/system-test/test_${{ inputs.test }}.py

--- a/test/system-test/test_all_seq.py
+++ b/test/system-test/test_all_seq.py
@@ -1,0 +1,465 @@
+import json
+import pytest
+from endpoints import heartbeat, key, listpubkeys, pubkey, keyReleasePolicy, unwrapKey, refresh
+from utils import get_test_attestation, get_test_public_wrapping_key, apply_kms_constitution, apply_key_release_policy, decrypted_wrapped_key, trust_jwt_issuer, remove_key_release_policy
+
+# These tests run on a single KMS instance in order to be cheaper regarding
+# Azure deployments.
+
+# Since the KMS is a stateful system, running certain tests will have side
+# effects which affects the behaviour for other tests.
+
+# Therefore, the order of the tests is important and changing the order will
+# likely break tests
+
+# To make this clearer, test names will include the expected state of the KMS
+
+def test_no_policy_no_keys_no_jwt_heartbeat(setup_kms_session):
+    status_code, heartbeat_json = heartbeat()
+    assert status_code == 200
+    assert heartbeat_json["status"] == "Service is running"
+
+
+@pytest.mark.xfail(strict=True) # TODO: Fix, see #167
+def test_no_policy_no_keys_no_jwt_listpubkeys(setup_kms_session):
+    status_code, pubkeys = listpubkeys()
+    assert status_code == 200
+    assert len(pubkeys["keys"]) == 0
+
+
+@pytest.mark.xfail(strict=True) # TODO: Fix #167
+def test_no_policy_no_keys_no_jwt_pubkey(setup_kms_session):
+    while True:
+        status_code, pubkey_json = pubkey()
+        if status_code != 202:
+            break
+    assert status_code == 404
+
+
+def test_no_policy_no_keys_no_jwt_pubkey_with_kid(setup_kms_session):
+    while True:
+        status_code, pubkey_json = pubkey(kid="doesntexist")
+        if status_code != 202:
+            break
+    assert status_code == 404
+
+
+@pytest.mark.xfail(strict=True) # TODO: Fix #167
+def test_no_policy_no_keys_no_jwt_key(setup_kms_session):
+    while True:
+        status_code, key_json = key(
+            attestation=get_test_attestation(),
+            wrapping_key=get_test_public_wrapping_key(),
+        )
+        if status_code != 202:
+            break
+    assert status_code == 404
+
+
+@pytest.mark.xfail(strict=True) # TODO: Fix #167
+def test_no_policy_no_keys_no_jwt_unwrapKey(setup_kms_session):
+    while True:
+        status_code, key_json = key(
+            attestation=get_test_attestation(),
+            wrapping_key=get_test_public_wrapping_key(),
+            wrappedKid="doesntexist",
+        )
+        if status_code != 202:
+            break
+    assert status_code == 404
+
+
+@pytest.mark.xfail(strict=True) # TODO: Fix #175
+def test_no_policy_no_keys_no_jwt_keyReleasePolicy(setup_kms_session):
+    status_code, key_release_json = keyReleasePolicy()
+    assert status_code == 200
+
+
+def test_no_policy_no_keys_no_jwt_set_key_release_policy(setup_kms_session):
+    apply_kms_constitution()
+    apply_key_release_policy()
+
+
+def test_set_policy_no_keys_no_jwt_keyReleasePolicy(setup_kms_session):
+    status_code, key_release_json = keyReleasePolicy()
+    assert status_code == 200
+
+
+@pytest.mark.xfail(strict=True) # TODO: Fix #167
+def test_set_policy_no_keys_no_jwt_pubkey(setup_kms_session):
+    while True:
+        status_code, pubkey_json = pubkey()
+        if status_code != 202:
+            break
+    assert status_code == 404
+
+
+def test_set_policy_no_keys_no_jwt_pubkey_with_kid(setup_kms_session):
+    while True:
+        status_code, pubkey_json = pubkey(kid="doesntexist")
+        if status_code != 202:
+            break
+    assert status_code == 404
+
+
+@pytest.mark.xfail(strict=True) # TODO: Fix #167
+def test_set_policy_no_keys_no_jwt_key(setup_kms_session):
+    while True:
+        status_code, key_json = key(
+            attestation=get_test_attestation(),
+            wrapping_key=get_test_public_wrapping_key(),
+        )
+        if status_code != 202:
+            break
+    assert status_code == 404
+
+
+@pytest.mark.xfail(strict=True) # TODO: Fix #167
+def test_set_policy_no_keys_no_jwt_unwrapKey(setup_kms_session):
+    while True:
+        status_code, key_json = key(
+            attestation=get_test_attestation(),
+            wrapping_key=get_test_public_wrapping_key(),
+            wrappedKid="doesntexist",
+        )
+        if status_code != 202:
+            break
+    assert status_code == 404
+
+
+def test_set_policy_no_keys_no_jwt_refresh_single(setup_kms_session):
+    status_code, refresh_json = refresh()
+    setup_kms_session["key_1_json"] = refresh_json
+    assert status_code == 200
+
+
+def test_set_policy_single_key_no_jwt_listpubkeys(setup_kms_session):
+    status_code, pubkeys = listpubkeys()
+    assert status_code == 200
+    assert len(pubkeys["keys"]) == 1
+
+
+def test_set_policy_single_key_no_jwt_pubkey(setup_kms_session):
+    while True:
+        status_code, pubkey_json = pubkey()
+        if status_code != 202:
+            break
+    assert status_code == 200
+    assert pubkey_json["id"] == 11
+
+
+def test_set_policy_single_key_no_jwt_pubkey_with_kid(setup_kms_session):
+    while True:
+        status_code, pubkey_json = pubkey(kid="doesntexist")
+        if status_code != 202:
+            break
+    assert status_code == 404
+
+
+def test_set_policy_single_key_no_jwt_key(setup_kms_session):
+    while True:
+        status_code, key_json = key(
+            attestation=get_test_attestation(),
+            wrapping_key=get_test_public_wrapping_key(),
+        )
+        if status_code != 202:
+            break
+    assert status_code == 200
+
+    # Key isn't actually returned here, just the id of a key
+    assert key_json["wrappedKid"] != ""
+    assert key_json["wrapped"] == ""
+
+
+def test_set_policy_single_key_no_jwt_unwrapKey(setup_kms_session):
+    while True:
+        status_code, key_json = key(
+            attestation=get_test_attestation(),
+            wrapping_key=get_test_public_wrapping_key(),
+        )
+        if status_code != 202:
+            break
+    assert status_code == 200
+
+    while True:
+        status_code, unwrapped_json = unwrapKey(
+            attestation=get_test_attestation(),
+            wrapping_key=get_test_public_wrapping_key(),
+            wrappedKid=key_json["wrappedKid"],
+        )
+        if status_code != 202:
+            break
+    assert status_code == 200
+    unwrapped = decrypted_wrapped_key(unwrapped_json["wrapped"])
+    unwrapped_json = json.loads(unwrapped)
+    print(unwrapped_json)
+    assert unwrapped_json["kty"] == "OKP"
+
+
+def test_set_policy_single_key_no_jwt_pubkey_with_invalid_kid(setup_kms_session):
+    while True:
+        status_code, pubkey_json = pubkey(kid = "doesntexist")
+        if status_code != 202:
+            break
+    assert status_code == 404
+
+
+def test_set_policy_single_key_no_jwt_pubkey_with_valid_kid(setup_kms_session):
+    while True:
+        status_code, pubkey_json = pubkey(kid = setup_kms_session["key_1_json"]["kid"])
+        if status_code != 202:
+            break
+    assert status_code == 200
+
+
+def test_set_policy_single_key_no_jwt_pubkey_fmt_tink(setup_kms_session):
+    while True:
+        status_code, pubkey_json = pubkey(fmt="tink")
+        if status_code != 202:
+            break
+    try:
+        keys = pubkey_json["key"]
+        key = keys[0]
+        keyData = key["keyData"]
+    except KeyError:
+        raise Exception("Key doesn't match tink format")
+    assert status_code == 200
+    assert (
+        "status" in key and \
+        "outputPrefixType" in key and \
+            "typeUrl" in keyData and \
+            "value" in keyData and \
+            "keyMaterialType" in keyData
+    ), "Key doesn't match tink format"
+
+
+def test_set_policy_single_key_no_jwt_pubkey_fmt_jwk(setup_kms_session):
+    while True:
+        status_code, pubkey_json = pubkey(fmt="jwk")
+        if status_code != 202:
+            break
+    assert status_code == 200
+    assert "crv" in pubkey_json
+    assert "kty" in pubkey_json
+    assert "x" in pubkey_json
+
+
+def test_set_policy_single_key_no_jwt_pubkey_fmt_invalid(setup_kms_session):
+    while True:
+        status_code, pubkey_json = pubkey(fmt="invalid_fmt")
+        if status_code != 202:
+            break
+    assert status_code == 400
+
+
+def test_set_policy_single_key_no_jwt_key_with_invalid_kid(setup_kms_session):
+    while True:
+        status_code, key_json = key(
+            attestation=get_test_attestation(),
+            wrapping_key=get_test_public_wrapping_key(),
+            kid = "doesntexist"
+        )
+        if status_code != 202:
+            break
+    assert status_code == 404
+
+
+def test_set_policy_single_key_no_jwt_key_with_valid_kid(setup_kms_session):
+    while True:
+        status_code, key_json = key(
+            attestation=get_test_attestation(),
+            wrapping_key=get_test_public_wrapping_key(),
+            kid = setup_kms_session["key_1_json"]["kid"]
+        )
+        if status_code != 202:
+            break
+    assert status_code == 200
+
+
+def test_set_policy_single_key_no_jwt_key_fmt_tink(setup_kms_session):
+    while True:
+        status_code, key_json = key(
+            attestation=get_test_attestation(),
+            wrapping_key=get_test_public_wrapping_key(),
+            fmt="tink",
+        )
+        if status_code != 202:
+            break
+    assert status_code == 200
+    assert key_json["wrappedKid"] != ""
+
+
+def test_set_policy_single_key_no_jwt_key_fmt_jwk(setup_kms_session):
+    while True:
+        status_code, key_json = key(
+            attestation=get_test_attestation(),
+            wrapping_key=get_test_public_wrapping_key(),
+            fmt="jwk",
+        )
+        if status_code != 202:
+            break
+    assert status_code == 200
+
+    # Key isn't actually returned here, just the id of a key
+    assert key_json["wrappedKid"] != ""
+    assert key_json["wrapped"] == ""
+
+
+def test_set_policy_single_key_no_jwt_key_fmt_invalid(setup_kms_session):
+    while True:
+        status_code, key_json = key(
+            attestation=get_test_attestation(),
+            wrapping_key=get_test_public_wrapping_key(),
+            fmt="invalid",
+        )
+        if status_code != 202:
+            break
+    assert status_code == 400
+
+
+# def test_key_valid_attestation_not_accepted(setup_kms): ...
+
+
+# def test_key_incorrectly_signed_attestation(setup_kms): ...
+
+
+def test_set_policy_single_key_no_jwt_trust_jwt_issuer(setup_kms_session, setup_jwt_issuer_session):
+    trust_jwt_issuer()
+
+
+def test_set_policy_single_key_set_jwt_key_jwt_auth(setup_kms_session):
+    while True:
+        status_code, key_json = key(
+            attestation=get_test_attestation(),
+            wrapping_key=get_test_public_wrapping_key(),
+            auth="jwt"
+        )
+        if status_code != 202:
+            break
+    assert status_code == 200
+
+    # Key isn't actually returned here, just the id of a key
+    assert key_json["wrappedKid"] != ""
+    assert key_json["wrapped"] == ""
+
+
+def test_set_policy_single_key_set_jwt_refresh_multiple(setup_kms_session):
+    status_code, refresh_json = refresh()
+    setup_kms_session["key_2_json"] = refresh_json
+    assert status_code == 200
+
+
+def test_set_policy_multiple_keys_set_jwt_listpubkeys(setup_kms_session):
+    status_code, pubkeys = listpubkeys()
+    assert status_code == 200
+    assert len(pubkeys["keys"]) == 1
+
+
+def test_set_policy_multiple_keys_set_jwt_pubkey_no_kid(setup_kms_session):
+    while True:
+        status_code, pubkey_json = pubkey()
+        if status_code != 202:
+            break
+    assert status_code == 200
+    assert pubkey_json["kid"].endswith("_2")
+
+
+def test_set_policy_multiple_keys_set_jwt_pubkey_first_kid(setup_kms_session):
+    while True:
+        status_code, pubkey_json = pubkey(kid= setup_kms_session["key_1_json"]["kid"])
+        if status_code != 202:
+            break
+    assert status_code == 200
+    assert pubkey_json["kid"].endswith("_1")
+
+
+def test_set_policy_multiple_keys_set_jwt_key_no_kid(setup_kms_session):
+    while True:
+        status_code, key_json = key(
+            attestation=get_test_attestation(),
+            wrapping_key=get_test_public_wrapping_key(),
+        )
+        if status_code != 202:
+            break
+    assert status_code == 200
+    assert key_json["wrappedKid"].endswith("_2")
+
+
+def test_set_policy_multiple_keys_set_jwt_key_first_kid(setup_kms_session):
+    while True:
+        status_code, key_json = key(
+            attestation=get_test_attestation(),
+            wrapping_key=get_test_public_wrapping_key(),
+            kid= setup_kms_session["key_1_json"]["kid"],
+        )
+        if status_code != 202:
+            break
+    assert status_code == 200
+    assert key_json["wrappedKid"].endswith("_1")
+
+
+def test_set_policy_multiple_keys_set_jwt_unwrapKey_no_kid(setup_kms_session):
+    while True:
+        status_code, key_json = key(
+            attestation=get_test_attestation(),
+            wrapping_key=get_test_public_wrapping_key(),
+        )
+        if status_code != 202:
+            break
+    assert status_code == 200
+    assert key_json["wrappedKid"].endswith("_2")
+
+    while True:
+        status_code, unwrapped_json = unwrapKey(
+            attestation=get_test_attestation(),
+            wrapping_key=get_test_public_wrapping_key(),
+            wrappedKid=key_json["wrappedKid"],
+        )
+        if status_code != 202:
+            break
+    assert status_code == 200
+    unwrapped = decrypted_wrapped_key(unwrapped_json["wrapped"])
+    unwrapped_json = json.loads(unwrapped)
+    print(unwrapped_json)
+    assert unwrapped_json["kty"] == "OKP"
+
+
+def test_set_policy_multiple_keys_set_jwt_unwrapKey_first_kid(setup_kms_session):
+    while True:
+        status_code, key_json = key(
+            attestation=get_test_attestation(),
+            wrapping_key=get_test_public_wrapping_key(),
+            kid= setup_kms_session["key_1_json"]["kid"],
+        )
+        if status_code != 202:
+            break
+    assert status_code == 200
+    assert key_json["wrappedKid"].endswith("_1")
+
+    while True:
+        status_code, unwrapped_json = unwrapKey(
+            attestation=get_test_attestation(),
+            wrapping_key=get_test_public_wrapping_key(),
+            wrappedKid=key_json["wrappedKid"],
+        )
+        if status_code != 202:
+            break
+    assert status_code == 200
+    unwrapped = decrypted_wrapped_key(unwrapped_json["wrapped"])
+    unwrapped_json = json.loads(unwrapped)
+    print(unwrapped_json)
+    assert unwrapped_json["kty"] == "OKP"
+
+
+def test_set_policy_multiple_keys_set_jwt_unset_key_release_policy(setup_kms_session):
+    remove_key_release_policy()
+
+
+def test_unset_policy_multiple_keys_set_jwt_keyReleasePolicy(setup_kms_session):
+    status_code, key_release_json = keyReleasePolicy()
+    assert status_code == 200
+
+
+if __name__ == "__main__":
+    import pytest
+    pytest.main([__file__, '-s'])


### PR DESCRIPTION
### Motivation

We decided that the current test strategy for Azure based KMS testing was too expensive, particularly in the peak usage of ACI (and eventually ACL). 

This is because each individual test currently spins up it's own fresh KMS instance (and therefore a fresh Azure resource/s) in order to keep each test isolated from the side effects of other tests.

There are two potential solutions to the high peak usage. 
- Run the existing tests in sequence
  - However this doesn't reduce total usage
  - Perhaps more crucially, since deploying machines in Azure takes a lot of time, doing so sequentially for each test would make the total test time prohibitively long
- Write a new test which only needs one KMS instance
  - This gives up test isolation, but reduces the peak usage of Azure services.

We decided to opt for the latter

### Changes
- [x] Update conftest.py to specify fixtures which are the same as the current ones, but the KMS persists across the lifetime of the test session
- [x] Write a set of tests which use this new fixture, which assume a current state of the KMS which will be affected by other tests

The coverage of the tests should be nearly equal to the existing system tests

### Limitations

The main limitation of this approach, aside from tests being stateful, is that we can't test KMS states which are contradictory. For example, we cannot test both a KMS which has a key release policy but no key, and a KMS with no key release policy but with keys, because we cannot undo most state changes

### Future Work

Next step is to restructure the GitHub action test workflows in the following way:
- On PRs
  - Run all isolated tests on a local CCF sandbox container
  - Run the stateful tests in Azure (Az Cleanroom and eventually ACL)
- On demand/nightly
  - Run all isolated tests on a local CCF sandbox container
  - Run all isolated tests in azure, but sequentially