### PR TITLE
Only run stateful tests on ACI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,21 @@ jobs:
       - name: Print CCF logs
         run: cat workspace/sandbox_0/out
 
-  system:
+  system-stateless:
+    name: system / ccf sandbox / ${{ matrix.use_akv && 'akv' || 'local' }}_keys
     secrets: inherit # pragma: allowlist secret
+    matrix:
+      use_akv: [false, true]
     uses: ./.github/workflows/system-tests.yml
+    with:
+      env: ccf/sandbox_local
+      use_akv: ${{ matrix.use_akv }}
+
+  system-stateful:
+    name: system / az cleanroom / local_keys
+    secrets: inherit # pragma: allowlist secret
+    uses: ./.github/workflows/system-test.yml
+    with:
+      test-path: test_all_seq
+      env: ccf/sandbox/az-cleanroom-aci
+      use_akv: false

--- a/.github/workflows/system-test.yml
+++ b/.github/workflows/system-test.yml
@@ -7,28 +7,32 @@ permissions:
 on:
   workflow_dispatch:
     inputs:
-      test:
+      test_path:
         type: string
+        description: "Path to pytest file/s"
+      env:
+        type: string
+        description: The CCF service type to run KMS on
+      use_akv:
+        type: bool
+        description: Whether or not to store keys in AKV
   workflow_call:
     inputs:
-      test:
+      test_path:
         type: string
+        description: "Path to pytest file/s"
+      env:
+        type: string
+        description: The CCF service type to run KMS on
+      use_akv:
+        type: bool
+        description: Whether or not to store keys in AKV
 
 jobs:
 
   test:
-    name: ${{ inputs.test }} (${{ matrix.config.env }}) (${{ matrix.config.use_akv && 'akv' || 'local' }}_keys)
+    name: ${{ inputs.test }} (${{ inputs.env }}) (${{ inputs.use_akv && 'akv' || 'local' }}_keys)
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        config:
-          - env: sandbox_local
-            use_akv: false
-          - env: sandbox_local
-            use_akv: true
-          - env: az-cleanroom-aci
-            use_akv: false
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -51,8 +55,8 @@ jobs:
 
       - name: Run System Tests
         env:
-          TEST_ENVIRONMENT: ccf/${{ matrix.config.env }}
-          USE_AKV: ${{ matrix.config.use_akv }}
+          TEST_ENVIRONMENT: ccf/${{ inputs.env }}
+          USE_AKV: ${{ inputs.use_akv }}
         run: |
           pytest -sv \
-            test/system-test/test_${{ inputs.test }}.py
+            test/system-test/${{ inputs.test_path }}.py

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -6,7 +6,19 @@ permissions:
 
 on:
   workflow_dispatch:
+    env:
+      type: string
+      description: The CCF service type to run KMS on
+    use_akv:
+      type: bool
+      description: Whether or not to store keys in AKV
   workflow_call:
+    env:
+      type: string
+      description: The CCF service type to run KMS on
+    use_akv:
+      type: bool
+      description: Whether or not to store keys in AKV
 
 jobs:
   discover-tests:
@@ -20,7 +32,7 @@ jobs:
       - name: Find Test Files
         id: find_tests
         run: |
-          TEST_FILES=$(cd test/system-test && find . -name 'test_*.py' | sed -e 's|^\./||' -e 's|^test_||' -e 's|\.py$||')
+          TEST_FILES=$(cd test/system-test && find . -name 'test_*.py' ! -name 'test_all_seq.py' | sed -e 's|^\./||' -e 's|^test_||' -e 's|\.py$||')
           JSON_ARRAY=$(printf '%s\n' "${TEST_FILES[@]}" | jq -R . | jq -s .)
           echo "tests=$JSON_ARRAY" | sed ':a;N;$!ba;s/\n//g' >> $GITHUB_OUTPUT
 
@@ -34,4 +46,6 @@ jobs:
         test: ${{ fromJson(needs.discover-tests.outputs.tests) }}
     uses: ./.github/workflows/system-test.yml
     with:
-      test: ${{ matrix.test }}
+      test_path: ${{ matrix.test }}
+      env: ${{ inputs.env }}
+      use_akv: ${{ inputs.use_akv }}


### PR DESCRIPTION
Follows on from #328 

### Motivation

Now we have tests which give us the best coverage possible on a single KMS instance, for PR runs, we can run just this test on Azure based KMS's