### PR TITLE
Return to using the DEV AND TEST subscription

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           client-id: ${{ secrets.MANAGED_ID_CLIENT_ID }}
           tenant-id: ${{ secrets.MANAGED_ID_TENANT_ID }}
-          subscription-id: 7ca35580-fc67-469c-91a7-68b38569ca6e
+          subscription-id: ${{ vars.SUBSCRIPTION }}
 
       - run: |
           source services/cacitesting.env
@@ -49,7 +49,7 @@ jobs:
         with:
           client-id: ${{ secrets.MANAGED_ID_CLIENT_ID }}
           tenant-id: ${{ secrets.MANAGED_ID_TENANT_ID }}
-          subscription-id: 7ca35580-fc67-469c-91a7-68b38569ca6e
+          subscription-id: ${{ vars.SUBSCRIPTION }}
 
       - run: |
           source services/cacitesting.env
@@ -78,7 +78,7 @@ jobs:
         with:
           client-id: ${{ secrets.MANAGED_ID_CLIENT_ID }}
           tenant-id: ${{ secrets.MANAGED_ID_TENANT_ID }}
-          subscription-id: 7ca35580-fc67-469c-91a7-68b38569ca6e
+          subscription-id: ${{ vars.SUBSCRIPTION }}
 
       - run: |
           source services/cacitesting.env

--- a/.github/workflows/system-test.yml
+++ b/.github/workflows/system-test.yml
@@ -47,7 +47,7 @@ jobs:
           # Use subject identifier repo:<organization>/<repo>:ref:refs/heads/<branch> for running manual CI's
           client-id: ${{ secrets.MANAGED_ID_CLIENT_ID }}
           tenant-id: ${{ secrets.MANAGED_ID_TENANT_ID }}
-          subscription-id: 7ca35580-fc67-469c-91a7-68b38569ca6e
+          subscription-id: ${{ vars.SUBSCRIPTION }}
 
       - name: Run System Tests
         env:

--- a/.github/workflows/test-orchestrator.yml
+++ b/.github/workflows/test-orchestrator.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           client-id: ${{ secrets.MANAGED_ID_CLIENT_ID }}
           tenant-id: ${{ secrets.MANAGED_ID_TENANT_ID }}
-          subscription-id: 7ca35580-fc67-469c-91a7-68b38569ca6e
+          subscription-id: ${{ vars.SUBSCRIPTION }}
 
       - name: Install Dependencies
         run: pip install -r scripts/ccf/az-cleanroom-aci/orchestrator/requirements.txt

--- a/services/cacitesting.env
+++ b/services/cacitesting.env
@@ -1,5 +1,5 @@
 # Core Environment Variables
-export SUBSCRIPTION=7ca35580-fc67-469c-91a7-68b38569ca6e
+export SUBSCRIPTION=85c61f94-8912-4e82-900e-6ab44de9bdf8
 export RESOURCE_GROUP=azure-key-management-service
 export REGISTRY=azurekms.azurecr.io
 export MANAGED_IDENTITY=azure-key-management-service-id


### PR DESCRIPTION
### Motivation

The exception to deploy storage accounts with shared key authentication (which is a requirement for deployment a az cleanroom CCF network) is now active. This means we can deploy everything on our DEV AND TEST subscription instead of using the parakeet subscription.