### PR TITLE
Speed up system test dependency install

### DIFF
--- a/.github/workflows/system-test.yml
+++ b/.github/workflows/system-test.yml
@@ -38,7 +38,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           ./scripts/tools/install-c-aci-testing.sh
-          pip install pytest==8.3.3 pytest-xdist==3.6.1 cryptography==43.0.3
+          pip install pytest==8.3.3 pytest-xdist==3.6.1 pycryptodome==3.21.0
 
       - name: Log into Azure
         uses: azure/login@v2

--- a/.github/workflows/system-test.yml
+++ b/.github/workflows/system-test.yml
@@ -36,7 +36,9 @@ jobs:
       - name: Install Dependencies
         env:
           GH_TOKEN: ${{ github.token }}
-        run: ./scripts/tools/install-deps.sh
+        run: |
+          ./scripts/tools/install-c-aci-testing.sh
+          pip install pytest==8.3.3 pytest-xdist==3.6.1 python-dotenv==1.0.1
 
       - name: Log into Azure
         uses: azure/login@v2

--- a/.github/workflows/system-test.yml
+++ b/.github/workflows/system-test.yml
@@ -38,7 +38,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           ./scripts/tools/install-c-aci-testing.sh
-          pip install pytest==8.3.3 pytest-xdist==3.6.1 pycryptodome==3.21.0
+          pip install pytest==8.3.3 pytest-xdist==3.6.1 pycryptodome==3.21.0 ccf==5.0.11
 
       - name: Log into Azure
         uses: azure/login@v2

--- a/.github/workflows/system-test.yml
+++ b/.github/workflows/system-test.yml
@@ -38,7 +38,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           ./scripts/tools/install-c-aci-testing.sh
-          pip install pytest==8.3.3 pytest-xdist==3.6.1 python-dotenv==1.0.1
+          pip install pytest==8.3.3 pytest-xdist==3.6.1 cryptography==43.0.3
 
       - name: Log into Azure
         uses: azure/login@v2


### PR DESCRIPTION
### Motivation

Running several PRs, far too long (~10 mins) is spent installing dependencies which are likely unnecessary. #294 Attempts to solve this problem, however some of the older tests fail.

This PR removes the unnecessary dependencies for the system tests. **This speeds up the install deps step from ~10 minutes to ~10 seconds, for simple tests that takes total time from 12 minutes to 2 minutes**