### PR TITLE
Mark expected failures in stateless tests on ACL

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -69,10 +69,13 @@ jobs:
         config:
           - env: sandbox_local
             use_akv: false
+            parallel: true
           - env: sandbox_local
             use_akv: true
+            parallel: true
           - env: az-cleanroom-aci
             use_akv: false
+            parallel: false
           - env: acl
             use_akv: false
             parallel: false
@@ -80,3 +83,4 @@ jobs:
     with:
       env: ${{ matrix.config.env }}
       use_akv: ${{ matrix.config.use_akv }}
+      parallel: ${{ matrix.config.parallel }}

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -26,8 +26,8 @@ on:
         type: boolean
         description: Whether or not to store keys in AKV
       parallel:
-        type: boolean
-        default: true
+        type: string
+        default: 'true'
         description: Whether to run tests in parallel
 
 jobs:

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -51,7 +51,7 @@ jobs:
     secrets: inherit # pragma: allowlist secret
     strategy:
       fail-fast: false
-      max-parallel: ${{ inputs.parallel && 2 || 1 }}
+      max-parallel: ${{ inputs.parallel == 'true' && 2 || 1 }}
       matrix:
         test: ${{ fromJson(needs.discover-tests.outputs.tests) }}
     uses: ./.github/workflows/system-test.yml

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -25,9 +25,9 @@ on:
       use_akv:
         type: boolean
         description: Whether or not to store keys in AKV
-      max-parallel:
-        type: number
-        default: 999
+      parallel:
+        type: boolean
+        default: true
         description: Whether to run tests in parallel
 
 jobs:
@@ -51,7 +51,7 @@ jobs:
     secrets: inherit # pragma: allowlist secret
     strategy:
       fail-fast: false
-      max-parallel: ${{ inputs.max-parallel }}
+      max-parallel: ${{ inputs.parallel == true && 999 || 1 }}
       matrix:
         test: ${{ fromJson(needs.discover-tests.outputs.tests) }}
     uses: ./.github/workflows/system-test.yml

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -51,7 +51,7 @@ jobs:
     secrets: inherit # pragma: allowlist secret
     strategy:
       fail-fast: false
-      max-parallel: ${{ inputs.parallel == true && 2 || 1 }}
+      max-parallel: ${{ inputs.parallel && 2 || 1 }}
       matrix:
         test: ${{ fromJson(needs.discover-tests.outputs.tests) }}
     uses: ./.github/workflows/system-test.yml

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -25,9 +25,9 @@ on:
       use_akv:
         type: boolean
         description: Whether or not to store keys in AKV
-      parallel:
-        type: string
-        default: 'true'
+      max-parallel:
+        type: number
+        default: 999
         description: Whether to run tests in parallel
 
 jobs:
@@ -51,7 +51,7 @@ jobs:
     secrets: inherit # pragma: allowlist secret
     strategy:
       fail-fast: false
-      max-parallel: ${{ inputs.parallel == 'true' && 2 || 1 }}
+      max-parallel: ${{ inputs.max-parallel }}
       matrix:
         test: ${{ fromJson(needs.discover-tests.outputs.tests) }}
     uses: ./.github/workflows/system-test.yml

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -51,7 +51,7 @@ jobs:
     secrets: inherit # pragma: allowlist secret
     strategy:
       fail-fast: false
-      max-parallel: ${{ inputs.parallel == true && 999 || 1 }}
+      max-parallel: ${{ inputs.parallel == true && 2 || 1 }}
       matrix:
         test: ${{ fromJson(needs.discover-tests.outputs.tests) }}
     uses: ./.github/workflows/system-test.yml

--- a/test/system-test/test_constitution.py
+++ b/test/system-test/test_constitution.py
@@ -1,8 +1,14 @@
+import os
 import pytest
 import tempfile
 
 from utils import apply_kms_constitution, propose, get_test_action, get_test_proposal
 
+@pytest.mark.xfail(
+    os.getenv("TEST_ENVIRONMENT") == "ccf/acl",
+    strict=True,
+    reason="Governance operations need to move to user endpoints",
+)
 def test_constitution_auto_accept(setup_kms):
     with get_test_action() as action_file:
         apply_kms_constitution(actions=action_file.name)
@@ -12,6 +18,11 @@ def test_constitution_auto_accept(setup_kms):
         assert proposal_response["state"] == "Accepted"
 
 
+@pytest.mark.xfail(
+    os.getenv("TEST_ENVIRONMENT") == "ccf/acl",
+    strict=True,
+    reason="Governance operations need to move to user endpoints",
+)
 def test_constitution_majority_vote(setup_kms):
     with get_test_action() as action_file:
         apply_kms_constitution(resolve="majority_vote", actions=action_file.name)

--- a/test/system-test/test_governance.py
+++ b/test/system-test/test_governance.py
@@ -1,14 +1,25 @@
+import os
 import pytest
 
 from utils import add_member, apply_kms_constitution, member_info, use_member, vote
 
 
+@pytest.mark.xfail(
+    os.getenv("TEST_ENVIRONMENT") == "ccf/acl",
+    strict=True,
+    reason="Governance operations need to move to user endpoints",
+)
 def test_add_member(setup_kms):
     member_name = "test-new-member"
     add_member(member_name)
     member = member_info(member_name)
     assert member['status'] == "Active"
 
+@pytest.mark.xfail(
+    os.getenv("TEST_ENVIRONMENT") == "ccf/acl",
+    strict=True,
+    reason="Governance operations need to move to user endpoints",
+)
 def test_add_member_with_voting(setup_kms):
     apply_kms_constitution(resolve="majority_vote")
     member_name = "test-new-member"
@@ -17,6 +28,11 @@ def test_add_member_with_voting(setup_kms):
     vote(member_info(member_name)["proposalId"], "accept")
     assert member_info(member_name)["status"] == "Accepted"
 
+@pytest.mark.xfail(
+    os.getenv("TEST_ENVIRONMENT") == "ccf/acl",
+    strict=True,
+    reason="Governance operations need to move to user endpoints",
+)
 def test_use_member(setup_kms):
     member_name = "test-new-member"
     add_member(member_name)

--- a/test/system-test/test_key.py
+++ b/test/system-test/test_key.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 from endpoints import key, refresh
 from utils import apply_kms_constitution, apply_key_release_policy, trust_jwt_issuer, get_test_attestation, get_test_public_wrapping_key, decrypted_wrapped_key
@@ -16,6 +17,11 @@ def test_no_keys(setup_kms):
     assert status_code == 404
 
 
+@pytest.mark.xfail(
+    os.getenv("TEST_ENVIRONMENT") == "ccf/acl",
+    strict=True,
+    reason="Governance operations need to move to user endpoints",
+)
 def test_no_key_release_policy(setup_kms):
     apply_kms_constitution()
     refresh()
@@ -29,6 +35,11 @@ def test_no_key_release_policy(setup_kms):
     assert status_code == 500
 
 
+@pytest.mark.xfail(
+    os.getenv("TEST_ENVIRONMENT") == "ccf/acl",
+    strict=True,
+    reason="Governance operations need to move to user endpoints",
+)
 def test_with_keys_and_policy(setup_kms):
     apply_kms_constitution()
     apply_key_release_policy()
@@ -46,6 +57,11 @@ def test_with_keys_and_policy(setup_kms):
     assert key_json["wrappedKid"] != ""
     assert key_json["wrapped"] == ""
 
+@pytest.mark.xfail(
+    os.getenv("TEST_ENVIRONMENT") == "ccf/acl",
+    strict=True,
+    reason="Governance operations need to move to user endpoints",
+)
 def test_with_keys_and_policy_jwt_auth(setup_kms, setup_jwt_issuer):
     apply_kms_constitution()
     apply_key_release_policy()
@@ -66,6 +82,11 @@ def test_with_keys_and_policy_jwt_auth(setup_kms, setup_jwt_issuer):
     assert key_json["wrapped"] == ""
 
 
+@pytest.mark.xfail(
+    os.getenv("TEST_ENVIRONMENT") == "ccf/acl",
+    strict=True,
+    reason="Governance operations need to move to user endpoints",
+)
 def test_key_with_multiple(setup_kms):
     apply_kms_constitution()
     apply_key_release_policy()
@@ -88,6 +109,11 @@ def test_key_with_multiple(setup_kms):
 # def test_key_incorrectly_signed_attestation(setup_kms): ...
 
 
+@pytest.mark.xfail(
+    os.getenv("TEST_ENVIRONMENT") == "ccf/acl",
+    strict=True,
+    reason="Governance operations need to move to user endpoints",
+)
 def test_key_invalid_wrapping_key(setup_kms):
     # Because privacy sandbox has a two endpoint scheme to return a wrapped key
     # then unwrap it but we don't need it, this endpoint doesn't care about the
@@ -112,6 +138,11 @@ def test_key_invalid_wrapping_key(setup_kms):
 # Test kid parameter
 
 
+@pytest.mark.xfail(
+    os.getenv("TEST_ENVIRONMENT") == "ccf/acl",
+    strict=True,
+    reason="Governance operations need to move to user endpoints",
+)
 def test_key_kid_not_present_with_other_keys(setup_kms):
     refresh()
     refresh()
@@ -128,6 +159,11 @@ def test_key_kid_not_present_with_other_keys(setup_kms):
     assert status_code == 404
 
 
+@pytest.mark.xfail(
+    os.getenv("TEST_ENVIRONMENT") == "ccf/acl",
+    strict=True,
+    reason="Governance operations need to move to user endpoints",
+)
 def test_key_kid_not_present_without_other_keys(setup_kms):
     apply_kms_constitution()
     apply_key_release_policy()
@@ -142,6 +178,11 @@ def test_key_kid_not_present_without_other_keys(setup_kms):
     assert status_code == 404
 
 
+@pytest.mark.xfail(
+    os.getenv("TEST_ENVIRONMENT") == "ccf/acl",
+    strict=True,
+    reason="Governance operations need to move to user endpoints",
+)
 def test_key_kid_present(setup_kms):
     apply_kms_constitution()
     apply_key_release_policy()
@@ -162,6 +203,11 @@ def test_key_kid_present(setup_kms):
 # Test fmt parameter
 
 
+@pytest.mark.xfail(
+    os.getenv("TEST_ENVIRONMENT") == "ccf/acl",
+    strict=True,
+    reason="Governance operations need to move to user endpoints",
+)
 def test_key_fmt_tink(setup_kms):
     apply_kms_constitution()
     apply_key_release_policy()
@@ -178,6 +224,11 @@ def test_key_fmt_tink(setup_kms):
     assert key_json["wrappedKid"] != ""
 
 
+@pytest.mark.xfail(
+    os.getenv("TEST_ENVIRONMENT") == "ccf/acl",
+    strict=True,
+    reason="Governance operations need to move to user endpoints",
+)
 def test_key_fmt_jwk(setup_kms):
     apply_kms_constitution()
     apply_key_release_policy()
@@ -197,6 +248,11 @@ def test_key_fmt_jwk(setup_kms):
     assert key_json["wrapped"] == ""
 
 
+@pytest.mark.xfail(
+    os.getenv("TEST_ENVIRONMENT") == "ccf/acl",
+    strict=True,
+    reason="Governance operations need to move to user endpoints",
+)
 def test_key_fmt_invalid(setup_kms):
     apply_kms_constitution()
     apply_key_release_policy()

--- a/test/system-test/test_keyReleasePolicy.py
+++ b/test/system-test/test_keyReleasePolicy.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 from utils import apply_kms_constitution, apply_key_release_policy, remove_key_release_policy
 from endpoints import keyReleasePolicy
@@ -11,6 +12,11 @@ def test_keyReleasePolicy_with_no_policy(setup_kms):
     assert status_code == 200
 
 
+@pytest.mark.xfail(
+    os.getenv("TEST_ENVIRONMENT") == "ccf/acl",
+    strict=True,
+    reason="Governance operations need to move to user endpoints",
+)
 def test_keyReleasePolicy_with_policy_added(setup_kms):
     apply_kms_constitution()
     apply_key_release_policy()
@@ -18,6 +24,11 @@ def test_keyReleasePolicy_with_policy_added(setup_kms):
     assert status_code == 200
 
 
+@pytest.mark.xfail(
+    os.getenv("TEST_ENVIRONMENT") == "ccf/acl",
+    strict=True,
+    reason="Governance operations need to move to user endpoints",
+)
 def test_keyReleasePolicy_with_policy_added_then_removed(setup_kms):
     apply_kms_constitution()
     apply_key_release_policy()

--- a/test/system-test/test_keyRotationPolicy.py
+++ b/test/system-test/test_keyRotationPolicy.py
@@ -1,4 +1,5 @@
 import json
+import os
 import pytest
 import time
 from endpoints import key, refresh, unwrapKey
@@ -14,6 +15,11 @@ from utils import (
 
 
 # Test the key retrieval during the grace period with key rotation policy.
+@pytest.mark.xfail(
+    os.getenv("TEST_ENVIRONMENT") == "ccf/acl",
+    strict=True,
+    reason="Governance operations need to move to user endpoints",
+)
 def test_key_in_grace_period_with_rotation_policy(setup_kms):
     apply_kms_constitution()
     policy = {
@@ -51,6 +57,11 @@ def test_key_in_grace_period_with_rotation_policy(setup_kms):
     assert unwrapped_json.get("expiry") is not None
 
 # Test the key retrieval during the grace period without key rotation policy.
+@pytest.mark.xfail(
+    os.getenv("TEST_ENVIRONMENT") == "ccf/acl",
+    strict=True,
+    reason="Governance operations need to move to user endpoints",
+)
 def test_key_in_grace_period_without_rotation_policy(setup_kms):
     apply_kms_constitution()
     apply_key_release_policy()
@@ -78,6 +89,11 @@ def test_key_in_grace_period_without_rotation_policy(setup_kms):
     assert unwrapped_json.get("expiry") is None
 
 # Test the key retrieval during with custom key rotation policy.
+@pytest.mark.xfail(
+    os.getenv("TEST_ENVIRONMENT") == "ccf/acl",
+    strict=True,
+    reason="Governance operations need to move to user endpoints",
+)
 def test_key_in_grace_period_with_custom_rotation_policy(setup_kms):
     apply_kms_constitution()
     apply_settings_policy()

--- a/test/system-test/test_operations.py
+++ b/test/system-test/test_operations.py
@@ -5,6 +5,11 @@ import pytest
 from utils import get_node_info, nodes_scale, deploy_app_code
 
 
+@pytest.mark.xfail(
+    os.getenv("TEST_ENVIRONMENT") == "ccf/acl",
+    strict=True,
+    reason="Governance operations need to move to user endpoints",
+)
 def test_nodes_scale_up(setup_kms):
     nodes_requested = 2
 
@@ -22,6 +27,11 @@ def test_nodes_scale_up(setup_kms):
     assert len(node_ids) == nodes_requested
 
 
+@pytest.mark.xfail(
+    os.getenv("TEST_ENVIRONMENT") == "ccf/acl",
+    strict=True,
+    reason="Governance operations need to move to user endpoints",
+)
 def test_nodes_scale_down(setup_kms):
     nodes_requested = 3
 
@@ -44,6 +54,11 @@ def test_nodes_scale_down(setup_kms):
         except subprocess.CalledProcessError as e: ...
     assert available_nodes == nodes_requested
 
+@pytest.mark.xfail(
+    os.getenv("TEST_ENVIRONMENT") == "ccf/acl",
+    strict=True,
+    reason="Governance operations need to move to user endpoints",
+)
 def test_nodes_non_primary(setup_kms):
     nodes = nodes_scale(2, get_logs=True)["nodes"]
 

--- a/test/system-test/test_settingsPolicy.py
+++ b/test/system-test/test_settingsPolicy.py
@@ -8,6 +8,11 @@ from utils import (
 from endpoints import settingsPolicy
 
 
+@pytest.mark.xfail(
+    os.getenv("TEST_ENVIRONMENT") == "ccf/acl",
+    strict=True,
+    reason="Governance operations need to move to user endpoints",
+)
 def test_settingsPolicy_with_no_policy(setup_kms):
     status_code, settings_json = settingsPolicy()
     assert status_code == 200
@@ -26,6 +31,11 @@ def test_settingsPolicy_with_no_auth(setup_kms):
     assert status_code == 401
 
 
+@pytest.mark.xfail(
+    os.getenv("TEST_ENVIRONMENT") == "ccf/acl",
+    strict=True,
+    reason="Governance operations need to move to user endpoints",
+)
 def test_settingsPolicy_with_policy(setup_kms):
     apply_kms_constitution()
 
@@ -44,6 +54,11 @@ def test_settingsPolicy_with_policy(setup_kms):
     assert settings_json == policy
 
 
+@pytest.mark.xfail(
+    os.getenv("TEST_ENVIRONMENT") == "ccf/acl",
+    strict=True,
+    reason="Governance operations need to move to user endpoints",
+)
 def test_settingsPolicy_with_multiple_policy_sets(setup_kms):
     apply_kms_constitution()
 

--- a/test/system-test/test_unwrapkey.py
+++ b/test/system-test/test_unwrapkey.py
@@ -1,4 +1,5 @@
 import json
+import os
 import pytest
 from endpoints import key, refresh, unwrapKey
 from utils import apply_kms_constitution, apply_key_release_policy, trust_jwt_issuer, get_test_attestation, get_test_public_wrapping_key, decrypted_wrapped_key, apply_settings_policy
@@ -9,6 +10,11 @@ from utils import apply_kms_constitution, apply_key_release_policy, trust_jwt_is
 # Step 3, decrypt the wrapped private key
 
 
+@pytest.mark.xfail(
+    os.getenv("TEST_ENVIRONMENT") == "ccf/acl",
+    strict=True,
+    reason="Governance operations need to move to user endpoints",
+)
 def test_unwrap_key_and_decrypt(setup_kms):
     apply_kms_constitution()
     apply_key_release_policy()
@@ -36,6 +42,11 @@ def test_unwrap_key_and_decrypt(setup_kms):
     assert unwrapped_json["kty"] == "OKP"
 
 
+@pytest.mark.xfail(
+    os.getenv("TEST_ENVIRONMENT") == "ccf/acl",
+    strict=True,
+    reason="Governance operations need to move to user endpoints",
+)
 def test_unwrap_key_missing_attestation(setup_kms):
     apply_kms_constitution()
     apply_key_release_policy()
@@ -59,6 +70,11 @@ def test_unwrap_key_missing_attestation(setup_kms):
     assert status_code == 400
 
 
+@pytest.mark.xfail(
+    os.getenv("TEST_ENVIRONMENT") == "ccf/acl",
+    strict=True,
+    reason="Governance operations need to move to user endpoints",
+)
 def test_unwrap_key_missing_wrapping_key(setup_kms):
     apply_kms_constitution()
     apply_key_release_policy()
@@ -82,6 +98,11 @@ def test_unwrap_key_missing_wrapping_key(setup_kms):
     assert status_code == 400
 
 
+@pytest.mark.xfail(
+    os.getenv("TEST_ENVIRONMENT") == "ccf/acl",
+    strict=True,
+    reason="Governance operations need to move to user endpoints",
+)
 def test_unwrap_key_missing_wrappedKid(setup_kms):
     apply_kms_constitution()
     apply_key_release_policy()
@@ -97,6 +118,11 @@ def test_unwrap_key_missing_wrappedKid(setup_kms):
     assert status_code == 404
 
 
+@pytest.mark.xfail(
+    os.getenv("TEST_ENVIRONMENT") == "ccf/acl",
+    strict=True,
+    reason="Governance operations need to move to user endpoints",
+)
 def test_unwrap_key_without_refresh(setup_kms):
     apply_kms_constitution()
     apply_key_release_policy()


### PR DESCRIPTION
### Motivation

In #323, I forgot to run `daily.yml` which exposed two issues
- I wasn't properly setting the `parallel` field to make stateless ACL tests run sequentially.
- I haven't marked expected failures (due to lack of governance application endpoints) in the normal stateless tests

### Changes
- [x] Set `with: parallel: false` in ACL and Az cleanroom runs in `daily.yml`
- [x] Mark all expected failures in stateless tests like I have in stateful tests