### PR TITLE
Don't assume no-wait on ACL down

### DIFF
--- a/scripts/ccf/acl/down.sh
+++ b/scripts/ccf/acl/down.sh
@@ -15,7 +15,7 @@ acl-down() {
     fi
     export DEPLOYMENT_NAME
 
-    az confidentialledger delete -y --no-wait \
+    az confidentialledger delete -y "$@" \
         --name $DEPLOYMENT_NAME \
         --subscription $SUBSCRIPTION \
         --resource-group $RESOURCE_GROUP


### PR DESCRIPTION
### Motivation

When running ACL tests sequentially, we run into a problem where the ACL is still being deleted when we start the next test because of the `--no-wait` flag, so we don't want to include it in this case. 

Since we still want it sometimes to speed things up, we can still optionally include it