### PR TITLE
Ensure down in conftest.py unsets env variables

### DIFF
--- a/test/system-test/conftest.py
+++ b/test/system-test/conftest.py
@@ -120,14 +120,8 @@ def _setup_ccf():
         },
     )
 
-    os.environ = {k: v for k, v in os.environ.items() if k not in {
-        "DEPLOYMENT_NAME",
-        "WORKSPACE",
-        "KMS_URL",
-        "KMS_SERVICE_CERT_PATH",
-        "KMS_MEMBER_CERT_PATH",
-        "KMS_MEMBER_PRIVK_PATH",
-    }}
+    if "DEPLOYMENT_NAME" in os.environ:
+        del os.environ["DEPLOYMENT_NAME"]
 
 
 @pytest.fixture()

--- a/test/system-test/conftest.py
+++ b/test/system-test/conftest.py
@@ -120,6 +120,15 @@ def _setup_ccf():
         },
     )
 
+    os.environ = {k: v for k, v in os.environ.items() if k not in {
+        "DEPLOYMENT_NAME",
+        "WORKSPACE",
+        "KMS_URL",
+        "KMS_SERVICE_CERT_PATH",
+        "KMS_MEMBER_CERT_PATH",
+        "KMS_MEMBER_PRIVK_PATH",
+    }}
+
 
 @pytest.fixture()
 def setup_ccf():


### PR DESCRIPTION
### Why

Sometimes `daily.yml` fails because we attempt to start new ACL instances while the old one is still "in" the system. This is because we re-use the deployment name from the last run.

### How

- [x] In python, remove the unset env variables in down.sh