### PR TITLE
Refactor cleanup workflow to allowlist structure

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -10,7 +10,7 @@ on:
     - cron: "0 0 * * *"
 
 jobs:
-  cleanup-aci:
+  cleanup:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -23,74 +23,4 @@ jobs:
           tenant-id: ${{ secrets.MANAGED_ID_TENANT_ID }}
           subscription-id: ${{ vars.SUBSCRIPTION }}
 
-      - run: |
-          source services/cacitesting.env
-          aci_names=$(az container list \
-              --resource-group "$RESOURCE_GROUP" \
-              --query "[?starts_with(name, 'kms-') || starts_with(name, 'lb-')].name" \
-              -o tsv)
-
-          for name in $aci_names; do
-              echo "Deleting ACI: $name"
-              az container delete \
-                  --name "$name" \
-                  --resource-group "$RESOURCE_GROUP" \
-                  --yes
-          done
-
-  cleanup-storage:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Log into Azure
-        uses: azure/login@v2
-        with:
-          client-id: ${{ secrets.MANAGED_ID_CLIENT_ID }}
-          tenant-id: ${{ secrets.MANAGED_ID_TENANT_ID }}
-          subscription-id: ${{ vars.SUBSCRIPTION }}
-
-      - run: |
-          source services/cacitesting.env
-          storage_accounts=$(az storage account list \
-            --resource-group "$RESOURCE_GROUP" \
-            --query "[?starts_with(name, 'ccf')].name" \
-            -o tsv)
-
-          # Loop through each storage account and delete it
-          for account in $storage_accounts; do
-            echo "Deleting Storage Account: $account"
-            az storage account delete \
-              --name "$account" \
-              --resource-group "$RESOURCE_GROUP" \
-              --yes
-          done
-
-  cleanup-akv:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Log into Azure
-        uses: azure/login@v2
-        with:
-          client-id: ${{ secrets.MANAGED_ID_CLIENT_ID }}
-          tenant-id: ${{ secrets.MANAGED_ID_TENANT_ID }}
-          subscription-id: ${{ vars.SUBSCRIPTION }}
-
-      - run: |
-          source services/cacitesting.env
-          key_vaults=$(az keyvault list \
-            --resource-group "$RESOURCE_GROUP" \
-            --query "[].name" \
-            -o tsv \
-          )
-
-          for kv in $key_vaults; do
-            echo "Deleting Key Vault: $kv"
-            az keyvault delete \
-              --name "$kv" \
-              --resource-group "$RESOURCE_GROUP" > /dev/null 2>&1
-          done
+      - run: scripts/tools/cleanup_resource_group.sh

--- a/scripts/tools/cleanup_resource_group.sh
+++ b/scripts/tools/cleanup_resource_group.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+source services/cacitesting.env
+
+persistent_resources=(
+    "azurekms:Microsoft.ContainerRegistry/registries"
+    "azure-key-management-service-id:Microsoft.ManagedIdentity/userAssignedIdentities"
+    "azurekmsstorage:Microsoft.Storage/storageAccounts"
+)
+
+resources_json=$(az resource list \
+    --resource-group "$RESOURCE_GROUP" \
+    --query "[].{name:name, type:type, id:id}" \
+    -o json
+)
+
+echo "$resources_json" | jq -c '.[]' | while read -r resource; do
+    name=$(echo "$resource" | jq -r '.name')
+    type=$(echo "$resource" | jq -r '.type')
+    id=$(echo "$resource" | jq -r '.id')
+
+    skip=false
+    for persistent_resource in "${persistent_resources[@]}"; do
+        if [ "$persistent_resource" = "${name}:${type}" ]; then
+            echo "Skipping persistent resource: $name ($type)"
+            skip=true
+            break
+        fi
+    done
+
+    if [ "$skip" = false ]; then
+        echo "Deleting resource: $name ($type)"
+        # az resource delete --ids "$id"
+    fi
+done


### PR DESCRIPTION
### Why

I noticed after adding ACL support I forgot to add cleanup code to handle ACL instances. This led me to decide that a better system uses an allowlist of specific resources to keep and just deleting everything else.

This trades the chance to forget to add a persistent resource to the allow list and accidentally delete it for not needing to explicitly handle new resource types when added

### How

- [x] Implement a new script which deletes all azure resource not in an allowlist (denoted by resource name and type)
- [x] Update `cleanup.yml` to call this script