### PR TITLE
Run the daily workflow on feature branches

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -6,7 +6,9 @@ permissions:
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - feature/*
   workflow_dispatch:
   schedule:
     - cron: "0 1 * * *"


### PR DESCRIPTION
### Why

We have a feature branch for the work to move governance to application endpoints. In order to have proper test coverage, we should run `daily.yml` on pushes to that branch