### PR TITLE
Remove pandas dependency in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ GitPython==3.1.44
 httpx==0.27.2
 jinja2==3.1.5
 matplotlib==3.7.5
-pandas==2.0.3
 paramiko==3.5.0
 pyasn1==0.6.1
 PyJWT==2.9.0


### PR DESCRIPTION
### Why

We don't use it and installing it takes 10 minutes on all of our tests

- Unit tests go from 9m to 40s
- e2e tests go from 27m to 10m