### PR TITLE
Add tests for the `/auth` endpoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ KMS_URL ?= https://127.0.0.1:8000
 KEYS_DIR ?= ${KMS_WORKSPACE}/sandbox_common
 RUN_BACK ?= true
 CCF_PLATFORM ?= virtual
-JWT_ISSUER_WORKSPACE ?= ${PWD}/jwt_issuer_workspace
+JWT_ISSUER_WORKSPACE ?= ${PWD}/jwt_issuers_workspace/default
 
 DEPLOYMENT_ENV ?= $(if $(shell echo $(KMS_URL) | grep -E '127.0.0.1|localhost'),local,cloud)
 

--- a/scripts/kms/endpoints/auth.sh
+++ b/scripts/kms/endpoints/auth.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+auth() {
+    params=()
+    auth="jwt"
+
+    # Parse command-line arguments
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --auth)
+                auth="$2"
+                shift 2
+                ;;
+            *)
+                echo "Unknown parameter: $1"
+                exit 1
+                ;;
+        esac
+    done
+
+    auth_arg=()
+    if [[ "$auth" == "member_cert" ]]; then
+        auth_arg=(--cert $KMS_MEMBER_CERT_PATH --key $KMS_MEMBER_PRIVK_PATH)
+    elif [[ "$auth" == "jwt" ]]; then
+        auth_arg=(-H "Authorization: Bearer $(curl -X POST $JWT_ISSUER | jq -r '.access_token')")
+    fi
+
+    curl $KMS_URL/app/auth \
+        --cacert $KMS_SERVICE_CERT_PATH \
+        "${auth_arg[@]}" \
+        -H "Content-Type: application/json" \
+        -w '\n%{http_code}\n'
+}
+
+auth "$@"

--- a/test/system-test/conftest.py
+++ b/test/system-test/conftest.py
@@ -53,7 +53,7 @@ def _setup_jwt_issuer():
             ["./scripts/jwt_issuer/up.sh", "--build"],
             env={
                 **os.environ,
-                "JWT_ISSUER_WORKSPACE": f"{REPO_ROOT}/jwt_issuer_workspace",
+                "JWT_ISSUER_WORKSPACE": f"{REPO_ROOT}/jwt_issuers_workspace/default",
             },
         )
         yield

--- a/test/system-test/endpoints.py
+++ b/test/system-test/endpoints.py
@@ -31,6 +31,10 @@ def heartbeat(**kwargs):
     return call_endpoint("heartbeat", **kwargs)
 
 
+def auth(**kwargs):
+    return call_endpoint("auth", **kwargs)
+
+
 def key(**kwargs):
     return call_endpoint("key", **kwargs)
 

--- a/test/system-test/test_all_seq.py
+++ b/test/system-test/test_all_seq.py
@@ -382,8 +382,12 @@ def test_set_policy_single_key_no_jwt_auth_member_cert(setup_kms_session):
 
 
 def test_set_policy_single_key_no_jwt_auth_jwt(setup_kms_session):
-    with pytest.raises(CalledProcessError):
-        auth(auth="jwt")
+    try:
+        status_code, auth_json = auth(auth="jwt")
+        assert status_code == 401
+    except CalledProcessError:
+        with pytest.raises(CalledProcessError):
+            raise
 
 
 @pytest.mark.xfail(

--- a/test/system-test/test_all_seq.py
+++ b/test/system-test/test_all_seq.py
@@ -1,7 +1,8 @@
 import json
 import os
 import pytest
-from endpoints import heartbeat, key, listpubkeys, pubkey, keyReleasePolicy, unwrapKey, refresh
+from subprocess import CalledProcessError
+from endpoints import heartbeat, key, listpubkeys, pubkey, keyReleasePolicy, unwrapKey, refresh, auth
 from utils import get_test_attestation, get_test_public_wrapping_key, apply_kms_constitution, apply_key_release_policy, decrypted_wrapped_key, trust_jwt_issuer, remove_key_release_policy
 
 # These tests run on a single KMS instance in order to be cheaper regarding
@@ -374,8 +375,35 @@ def test_set_policy_single_key_no_jwt_key_fmt_invalid(setup_kms_session):
     strict=True,
     reason="Governance operations need to move to user endpoints",
 )
+def test_set_policy_single_key_no_jwt_auth_member_cert(setup_kms_session):
+    status_code, auth_json = auth(auth="member_cert")
+    assert status_code == 200
+    assert auth_json["auth"]["policy"] == "member_cert"
+
+
+def test_set_policy_single_key_no_jwt_auth_jwt(setup_kms_session):
+    with pytest.raises(CalledProcessError):
+        auth(auth="jwt")
+
+
+@pytest.mark.xfail(
+    os.getenv("TEST_ENVIRONMENT") == "ccf/acl",
+    strict=True,
+    reason="Governance operations need to move to user endpoints",
+)
 def test_set_policy_single_key_no_jwt_trust_jwt_issuer(setup_kms_session, setup_jwt_issuer_session):
     trust_jwt_issuer()
+
+
+@pytest.mark.xfail(
+    os.getenv("TEST_ENVIRONMENT") == "ccf/acl",
+    strict=True,
+    reason="Governance operations need to move to user endpoints",
+)
+def test_set_policy_single_key_set_jwt_auth_jwt(setup_kms_session):
+    status_code, auth_json = auth(auth="jwt")
+    assert status_code == 200
+    assert auth_json["auth"]["policy"] == "jwt"
 
 
 @pytest.mark.xfail(

--- a/test/system-test/test_auth.py
+++ b/test/system-test/test_auth.py
@@ -1,0 +1,22 @@
+from endpoints import auth
+from utils import apply_kms_constitution, trust_jwt_issuer
+
+
+def test_auth_member_cert(setup_kms):
+    status_code, auth_json = auth(auth="member_cert")
+    assert status_code == 200
+    assert auth_json["auth"]["policy"] == "member_cert"
+
+
+def test_auth_jwt(setup_kms, setup_jwt_issuer):
+    apply_kms_constitution()
+    trust_jwt_issuer()
+    status_code, auth_json = auth(auth="jwt")
+    assert status_code == 200
+    assert auth_json["auth"]["policy"] == "jwt"
+
+
+
+if __name__ == "__main__":
+    import pytest
+    pytest.main([__file__, "-s"])


### PR DESCRIPTION
### Why

This is useful in particular for testing the change for moving JWT issuer trust from governance to application code

### How

- [x] Add script to call `/auth`
- [x] Add system tests which use the script
- [x] Clean up output directory for JWT issuer 