### PR TITLE
Disable testing on az cleanroom based KMS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        env: [az-cleanroom-aci, acl]
+        env: [acl]
     uses: ./.github/workflows/system-test.yml
     with:
       test_path: test_all_seq

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -74,9 +74,6 @@ jobs:
           - env: sandbox_local
             use_akv: true
             parallel: true
-          - env: az-cleanroom-aci
-            use_akv: false
-            parallel: false
           - env: acl
             use_akv: false
             parallel: false


### PR DESCRIPTION
### Why

In order to get all of the features we needed, we install a custom build of the cleanroom extension in `scripts/ccf/az-cleanroom-aci/setup.sh`

However since this version doesn't get changes, we are now sufficiently stale that attestation validation fails (some expected version has moved on)

Since we're likely to move to ACL, it's only worth attempting to fix if it's cheap, however after spending some time doing a fresh build of the extension and the container image we previously had custom builds of it doesn't work.

Therefore I think the pragmatic thing for now is to disable this testing but keep the code. If we move back to cleanroom the code is still there and we just need to investigate and fix the custom builds mechanism. If we complete the move to ACL we can delete the az cleanroom management code