### PR TITLE
Revert version bumps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ docker==7.1.0
 GitPython==3.1.44
 httpx==0.27.2
 jinja2==3.1.5
-matplotlib==3.10.1
+matplotlib==3.7.5
 paramiko==3.5.0
 pyasn1==0.6.1
 PyJWT==2.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ matplotlib==3.7.5
 paramiko==3.5.0
 pyasn1==0.6.1
 PyJWT==2.9.0
-pre-commit==4.1.0
+pre-commit==3.5.0
 setuptools==72.0.0
 pytest==8.3.5
 pytest-xdist==3.6.1


### PR DESCRIPTION
### Why 

Privacy-sandbox-dev CI has been failing to build KMS. The logs claim it can't find the required version of pre-commit and matplotlib.

Quick solution is revert those bumps, I will also follow up with tests for building in the same way as privacy-sandbox-dev, and maybe investigating why it fails there and not here