### PR TITLE
Bump CCF image version to 5.0.13

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 ARG CCF_PLATFORM
-ARG CCF_VERSION=ccf-5.0.11
+ARG CCF_VERSION=ccf-5.0.13
 
 # Build Image ------------------------------------------------------------------
 


### PR DESCRIPTION
### Why 

Privacy-sandbox-dev CI fails with an attestation version issue, which I assume is fixed in the latest CCF version

