### PR TITLE
Bump CCF image version to 6.0.0-rc1

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 ARG CCF_PLATFORM
-ARG CCF_VERSION=ccf-5.0.11
+ARG CCF_VERSION=ccf-6.0.0-rc0
 
 # Build Image ------------------------------------------------------------------
 


### PR DESCRIPTION
### Why

This version supports latest ACI attestations