### PR TITLE
Fix the standalone image used for testing privacy-sandbox

### DIFF
--- a/.devcontainer/install_packages.sh
+++ b/.devcontainer/install_packages.sh
@@ -12,4 +12,5 @@ apt-get update && apt-get install -y \
     lsof \
     sudo \
     tar \
-    default-jre
+    default-jre \
+    gettext

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,87 +1,23 @@
 ARG CCF_PLATFORM
-ARG CCF_VERSION=ccf-5.0.11
+FROM ghcr.io/microsoft/ccf/app/dev/${CCF_PLATFORM}:ccf-6.0.0-rc0
 
-# Build Image ------------------------------------------------------------------
+RUN mkdir -p /kms
+WORKDIR /kms
 
-FROM ghcr.io/microsoft/ccf/app/dev/virtual:${CCF_VERSION} AS builder
+COPY .devcontainer/install_packages.sh /kms/.devcontainer/
+RUN .devcontainer/install_packages.sh
 
-COPY .devcontainer/install_packages.sh /src/
-RUN /src/install_packages.sh
-
-COPY .devcontainer/install_nodejs.sh /src/
+COPY .devcontainer/install_nodejs.sh /kms/.devcontainer/
 ENV NVM_DIR=/kms/.nvm
-RUN /src/install_nodejs.sh
+RUN .devcontainer/install_nodejs.sh
 
-COPY .devcontainer/setup_tinkey.sh /src/
-ENV TINKEY_VERSION=tinkey-1.10.1
-RUN /src/setup_tinkey.sh
+COPY requirements.txt /kms/
+RUN pip install -r requirements.txt
 
-# Copy minimal set of files to build KMS bundle to reduce rebuilds
-COPY Makefile /kms/Makefile
-COPY src /kms/src
-COPY scripts /kms/scripts
-COPY governance /kms/governance
-COPY package.json /kms/package.json
-COPY requirements.txt /kms/requirements.txt
-COPY rollup.config.js /kms/rollup.config.js
-COPY app.json /kms/app.json
-COPY build_bundle.js /kms/build_bundle.js
-COPY babel.config.json /kms/babel.config.json
-COPY buf.gen.yaml /kms/buf.gen.yaml
-COPY loader-register.js /kms/loader-register.js
-COPY test /kms/test
-COPY tsconfig.json /kms/tsconfig.json
+COPY . /kms
 
-WORKDIR /kms
-RUN make build
-
-# Run Image --------------------------------------------------------------------
-
-# While KMS relies on running on sandbox.sh we need to use dev image
-# FROM mcr.microsoft.com/ccf/app/run-js/${CCF_PLATFORM}:${CCF_VERSION}
-FROM ghcr.io/microsoft/ccf/app/dev/${CCF_PLATFORM}:${CCF_VERSION}
-
-COPY .devcontainer/install_nodejs.sh /src/
-RUN NVM_DIR=/root/.nvm /src/install_nodejs.sh
-
-COPY --from=builder /kms /kms
-WORKDIR /kms
-
-ARG CCF_PLATFORM
-ENV CCF_PLATFORM=${CCF_PLATFORM}
+RUN rm -rf .venv_ccf_sandbox
 ENV JWT_ISSUER_PORT=3000
-CMD /bin/bash -c ' \
-    mkdir -p workspace; \
-    mkdir -p workspace/proposals; \
-    \
-    (cd test/utils/jwt && KMS_WORKSPACE=/kms/workspace nohup npm run start > nohup.out 2>&1 &); \
-    ./scripts/wait_idp_ready.sh; \
-    export JWK=$( \
-        npx pem-jwk "./workspace/private.pem" \
-            | jq --arg cert "$(cat ./workspace/cert.pem)" \
-                '\''{kty, n, e} + {x5c: [$cert]} + {kid: "Demo IDP kid"}'\'' \
-    ); \
-    echo "\
-    { \
-        \"issuer\": \"http://Demo-jwt-issuer\", \
-        \"jwks\": { \
-            \"keys\": [ \
-                $JWK \
-            ] \
-        } \
-    }" | jq > ./workspace/proposals/set_jwt_issuer.json; \
-    ./scripts/set_python_env.sh; \
-    npm install; \
-    npm run build; \
-    env -i PATH=${PATH} KMS_WORKSPACE=workspace \
-        /opt/ccf_${CCF_PLATFORM}/bin/sandbox.sh \
-            --js-app-bundle ./dist/ \
-            --initial-member-count 3 \
-            --initial-user-count 1 \
-            --constitution ./governance/constitution/actions/kms.js \
-            --jwt-issuer workspace/proposals/set_jwt_issuer.json \
-            -v --http2 & \
-    ./scripts/kms_wait.sh; \
-    make setup; \
-    tail -f /kms/workspace/sandbox_0/out; \
-'
+
+CMD ./docker/run_kms_standalone.sh; \
+    sleep infinity

--- a/docker/run_kms_standalone.sh
+++ b/docker/run_kms_standalone.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+run_ccf() {
+    /opt/ccf_${CCF_PLATFORM:-virtual}/bin/sandbox.sh \
+        --http2 \
+        --initial-member-count 3 \
+        --initial-user-count 1 \
+        --http2 -v &
+
+    export WORKSPACE="$PWD/workspace"
+
+    until [ -f $WORKSPACE/sandbox_0/0.rpc_addresses ]; do
+        sleep 1
+    done
+
+    export KMS_URL="https://$(jq -r '.primary_rpc_interface' $WORKSPACE/sandbox_0/0.rpc_addresses)"
+
+    until curl -s -k -f $KMS_URL/node/state > /dev/null 2>&1; do
+        sleep 1
+    done
+
+    export KMS_SERVICE_CERT_PATH="$WORKSPACE/sandbox_common/service_cert.pem"
+    export KMS_MEMBER_CERT_PATH="$WORKSPACE/sandbox_common/member0_cert.pem"
+    export KMS_MEMBER_PRIVK_PATH="$WORKSPACE/sandbox_common/member0_privk.pem"
+
+    tail -f /kms/workspace/sandbox_0/out &
+}
+
+run_jwt_issuer() {
+    (
+        cd test/utils/jwt
+        KMS_WORKSPACE=$WORKSPACE npm run start 2>&1 &
+    )
+
+    export JWT_ISSUER_WORKSPACE=$WORKSPACE
+    export JWT_ISSUER="http://localhost:3000/token"
+
+    until curl -s -k -f -X POST $JWT_ISSUER > /dev/null 2>&1; do
+        sleep 1
+    done
+}
+
+run_ccf
+run_jwt_issuer
+
+./scripts/kms/js_app_set.sh
+
+./scripts/kms/constitution_set.sh \
+    --actions governance/constitution/actions/kms.js \
+    --resolve governance/constitution/resolve/auto_accept.js
+
+./scripts/kms/jwt_issuer_trust.sh
+
+./scripts/kms/settings_policy_set.sh
+
+./scripts/kms/release_policy_set.sh \
+    governance/proposals/set_key_release_policy_add.json
+
+./scripts/kms/key_rotation_policy_set.sh \
+    governance/proposals/set_key_rotation_policy.json
+
+./scripts/kms/endpoints/refresh.sh

--- a/docker/run_kms_standalone.sh
+++ b/docker/run_kms_standalone.sh
@@ -8,9 +8,10 @@ run_ccf() {
         --http2 \
         --initial-member-count 3 \
         --initial-user-count 1 \
-        --http2 -v "$@" &
+        "$@" &
 
     export WORKSPACE="$PWD/workspace"
+    mkdir -p $WORKSPACE/proposals
 
     until [ -f $WORKSPACE/sandbox_0/0.rpc_addresses ]; do
         sleep 1

--- a/docker/run_kms_standalone.sh
+++ b/docker/run_kms_standalone.sh
@@ -8,7 +8,7 @@ run_ccf() {
         --http2 \
         --initial-member-count 3 \
         --initial-user-count 1 \
-        --http2 -v &
+        --http2 -v "$@" &
 
     export WORKSPACE="$PWD/workspace"
 
@@ -43,7 +43,7 @@ run_jwt_issuer() {
     done
 }
 
-run_ccf
+run_ccf "$@"
 run_jwt_issuer
 
 ./scripts/kms/js_app_set.sh


### PR DESCRIPTION
### Why

The existing standalone image for KMS (which is a single docker image which can run CCF and puts the KMS on top) is very complex and is currently failing.