### PR TITLE
Add a test for the standalone KMS image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,3 +83,13 @@ jobs:
       test_path: test_all_seq
       env: ${{ matrix.env }}
       use_akv: false
+
+
+  standalone-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run Standalone Image
+        run: docker compose -f docker/docker-compose.yml up --wait

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,3 +6,7 @@ services:
       dockerfile: docker/Dockerfile
       args:
         - CCF_PLATFORM=${CCF_PLATFORM:-virtual}
+    healthcheck:
+      test: ["CMD", "curl", "-k", "--fail", "https://localhost:8000/app/listpubkeys"]
+      interval: 1s
+      retries: 120


### PR DESCRIPTION
### Why

For testing privacy sandbox, we want a single image which runs the KMS on top of a local CCF (so the CCF sandbox is sufficient). It will save us some time to test building this image on PRs

### How

- [x] Add a sanity check test for the standalone image