### PR TITLE
Move KMS standalone image CMD into a script

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,6 +32,7 @@ COPY buf.gen.yaml /kms/buf.gen.yaml
 COPY loader-register.js /kms/loader-register.js
 COPY test /kms/test
 COPY tsconfig.json /kms/tsconfig.json
+COPY docker/run_standalone_kms.sh /kms/docker/run_standalone_kms.sh
 
 WORKDIR /kms
 RUN make build
@@ -51,38 +52,4 @@ WORKDIR /kms
 ARG CCF_PLATFORM
 ENV CCF_PLATFORM=${CCF_PLATFORM}
 ENV JWT_ISSUER_PORT=3000
-CMD /bin/bash -c ' \
-    mkdir -p workspace; \
-    mkdir -p workspace/proposals; \
-    \
-    (cd test/utils/jwt && KMS_WORKSPACE=/kms/workspace nohup npm run start > nohup.out 2>&1 &); \
-    ./scripts/wait_idp_ready.sh; \
-    export JWK=$( \
-        npx pem-jwk "./workspace/private.pem" \
-            | jq --arg cert "$(cat ./workspace/cert.pem)" \
-                '\''{kty, n, e} + {x5c: [$cert]} + {kid: "Demo IDP kid"}'\'' \
-    ); \
-    echo "\
-    { \
-        \"issuer\": \"http://Demo-jwt-issuer\", \
-        \"jwks\": { \
-            \"keys\": [ \
-                $JWK \
-            ] \
-        } \
-    }" | jq > ./workspace/proposals/set_jwt_issuer.json; \
-    ./scripts/set_python_env.sh; \
-    npm install; \
-    npm run build; \
-    env -i PATH=${PATH} KMS_WORKSPACE=workspace \
-        /opt/ccf_${CCF_PLATFORM}/bin/sandbox.sh \
-            --js-app-bundle ./dist/ \
-            --initial-member-count 3 \
-            --initial-user-count 1 \
-            --constitution ./governance/constitution/actions/kms.js \
-            --jwt-issuer workspace/proposals/set_jwt_issuer.json \
-            -v --http2 & \
-    ./scripts/kms_wait.sh; \
-    make setup; \
-    tail -f /kms/workspace/sandbox_0/out; \
-'
+CMD /bin/bash -c 'docker/run_standalone_kms.sh'

--- a/docker/run_standalone_kms.sh
+++ b/docker/run_standalone_kms.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+mkdir -p workspace
+mkdir -p workspace/proposals
+
+(cd test/utils/jwt && KMS_WORKSPACE=/kms/workspace nohup npm run start > nohup.out 2>&1 &)
+./scripts/wait_idp_ready.sh
+
+JWK=$(npx pem-jwk "./workspace/private.pem" | \
+      jq --arg cert "$(cat ./workspace/cert.pem)" '{kty, n, e} + {x5c: [$cert]} + {kid: "Demo IDP kid"}')
+
+cat <<EOF | jq > ./workspace/proposals/set_jwt_issuer.json
+{
+  "issuer": "http://Demo-jwt-issuer",
+  "jwks": {
+    "keys": [
+      $JWK
+    ]
+  }
+}
+EOF
+
+./scripts/set_python_env.sh
+
+npm install
+npm run build
+
+env -i PATH=${PATH} KMS_WORKSPACE=workspace \
+  /opt/ccf_${CCF_PLATFORM}/bin/sandbox.sh \
+    --js-app-bundle ./dist/ \
+    --initial-member-count 3 \
+    --initial-user-count 1 \
+    --constitution ./governance/constitution/actions/kms.js \
+    --jwt-issuer workspace/proposals/set_jwt_issuer.json \
+    -v --http2 "$@" &
+
+./scripts/kms_wait.sh
+
+make setup
+
+tail -f /kms/workspace/sandbox_0/out


### PR DESCRIPTION
### Why

If the runtime CMD for the standalone KMS image is a script, we can iterate on it to fix dependabot issues without having to modify privacy sandbox dev code

### How

- [x] Move CMD into a script (17c985299fc6729138a57f914cbde866a1f2618e)
  - CI Run: https://github.com/microsoft/privacy-sandbox-dev/actions/runs/13787080470