### PR TITLE
Don't run the dummy JWT issuer in standalone KMS image

### DIFF
--- a/docker/run_standalone_kms.sh
+++ b/docker/run_standalone_kms.sh
@@ -16,7 +16,6 @@ env -i PATH=${PATH} KMS_WORKSPACE=workspace \
     --initial-member-count 3 \
     --initial-user-count 1 \
     --constitution ./governance/constitution/actions/kms.js \
-    --jwt-issuer workspace/proposals/set_jwt_issuer.json \
     -v --http2 "$@" &
 
 ./scripts/kms_wait.sh

--- a/docker/run_standalone_kms.sh
+++ b/docker/run_standalone_kms.sh
@@ -3,25 +3,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-mkdir -p workspace
 mkdir -p workspace/proposals
-
-(cd test/utils/jwt && KMS_WORKSPACE=/kms/workspace nohup npm run start > nohup.out 2>&1 &)
-./scripts/wait_idp_ready.sh
-
-JWK=$(npx pem-jwk "./workspace/private.pem" | \
-      jq --arg cert "$(cat ./workspace/cert.pem)" '{kty, n, e} + {x5c: [$cert]} + {kid: "Demo IDP kid"}')
-
-cat <<EOF | jq > ./workspace/proposals/set_jwt_issuer.json
-{
-  "issuer": "http://Demo-jwt-issuer",
-  "jwks": {
-    "keys": [
-      $JWK
-    ]
-  }
-}
-EOF
 
 ./scripts/set_python_env.sh
 


### PR DESCRIPTION
### Why

Simplifies the KMS standalone image, it looks like we use AAD for privacy-sandbox-dev so this isn't needed