### PR TITLE
Don't build the KMS in the runtime image

### DIFF
--- a/docker/run_standalone_kms.sh
+++ b/docker/run_standalone_kms.sh
@@ -25,9 +25,6 @@ EOF
 
 ./scripts/set_python_env.sh
 
-npm install
-npm run build
-
 env -i PATH=${PATH} KMS_WORKSPACE=workspace \
   /opt/ccf_${CCF_PLATFORM}/bin/sandbox.sh \
     --js-app-bundle ./dist/ \


### PR DESCRIPTION
### Why

We build the KMS in a previous step and copy it over