### PR TITLE
Add documentation to sign.sh

### DIFF
--- a/scripts/ccf/sign.sh
+++ b/scripts/ccf/sign.sh
@@ -33,17 +33,17 @@ ccf-sign() {
             --query accessToken --output tsv \
         )
         signature=$(mktemp)
-        payload=$(ccf_cose_sign1_prepare \
+        ccf_cose_sign1_prepare \
             --ccf-gov-msg-type $msg_type \
             --ccf-gov-msg-created_at $creation_time \
             --content $content \
             --signing-cert ${KMS_MEMBER_CERT_PATH} \
-            $extra_args)
-        curl -X POST -s \
-            -H "Authorization: Bearer $bearer_token" \
-            -H "Content-Type: application/json" \
-            "${AKV_URL}/keys/${AKV_KEY_NAME}/sign?api-version=7.2" \
-            -d $payload > $signature
+            $extra_args \
+            | curl -X POST -s \
+                -H "Authorization: Bearer $bearer_token" \
+                -H "Content-Type: application/json" \
+                "${AKV_URL}/keys/${AKV_KEY_NAME}/sign?api-version=7.2" \
+                -d @- > $signature
         ccf_cose_sign1_finish \
             --ccf-gov-msg-type $msg_type \
             --ccf-gov-msg-created_at $creation_time \


### PR DESCRIPTION
### Why

It was noted that it wasn't clear what `sign.sh` does, so adding some explanation. It was also suggested it would be clearer if we didn't pipe the output of `ccf_cose_sign1_prepare` into the signature request, however after checking the docs for the CCF code it is recommended to pass directly to AKV

### How
- [x] Add a comment at the top of the file explaining what the code does