### PR TITLE
Allow trusting JWT issuer without needing local certs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         run: cat workspace/sandbox_0/out
 
   system-stateless:
-    name: system / stateless (${{ inputs.use_akv && 'akv' || 'local' }}_keys)
+    name: system / stateless (${{ matrix.use_akv && 'akv' || 'local' }}_keys)
     secrets: inherit # pragma: allowlist secret
     strategy:
       fail-fast: false
@@ -57,16 +57,16 @@ jobs:
       use_akv: ${{ matrix.use_akv }}
 
   system-stateful:
-    name: system / stateful (local_keys)
+    name: system / stateful (${{ matrix.use_akv && 'akv' || 'local' }}_keys)
     secrets: inherit # pragma: allowlist secret
     strategy:
       fail-fast: false
       matrix:
-        env: [acl]
+        use_akv: [false, true]
     uses: ./.github/workflows/system-test.yml
     with:
       test_path: test_all_seq
-      env: ${{ matrix.env }}
+      env: acl
       use_akv: false
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,13 +61,14 @@ jobs:
     secrets: inherit # pragma: allowlist secret
     strategy:
       fail-fast: false
+      max-parallel: 1
       matrix:
         use_akv: [false, true]
     uses: ./.github/workflows/system-test.yml
     with:
       test_path: test_all_seq
       env: acl
-      use_akv: false
+      use_akv: ${{ matrix.use_akv }}
 
 
   standalone-image:

--- a/app.json
+++ b/app.json
@@ -6,7 +6,7 @@
         "js_function": "proposals",
         "forwarding_required": "always",
         "redirection_strategy": "none",
-        "authn_policies": ["member_cert", "user_cert", "jwt"],
+        "authn_policies": ["member_cert", "user_cert", "jwt", "user_cose_sign1"],
         "mode": "readwrite",
         "openapi": {
           "responses": {

--- a/scripts/ccf/acl/up.sh
+++ b/scripts/ccf/acl/up.sh
@@ -17,8 +17,7 @@ acl-assign-member() {
         --cacert $KMS_SERVICE_CERT_PATH \
         -X PATCH \
         -H "Content-Type: application/merge-patch+json" \
-        --cert $KMS_MEMBER_CERT_PATH \
-        --key $KMS_MEMBER_PRIVK_PATH \
+        -H "Authorization: Bearer $(az account get-access-token --resource https://confidential-ledger.azure.com --query accessToken -o tsv)" \
         -d "$(jq -n --arg member_id "$member_id" --argjson roles "$roles" '{
             user_id: $member_id,
             assignedRoles: $roles

--- a/scripts/ccf/acl/up.sh
+++ b/scripts/ccf/acl/up.sh
@@ -10,6 +10,8 @@ acl-up() {
     source $REPO_ROOT/services/cacitesting.env
     source $REPO_ROOT/scripts/ccf/acl/user_create.sh
 
+    USE_AKV=${USE_AKV:-false}
+
     DEPLOYMENT_NAME=${DEPLOYMENT_NAME:-$1}
     if [ -z "$DEPLOYMENT_NAME" ]; then
         read -p "Enter deployment name: " DEPLOYMENT_NAME

--- a/scripts/ccf/acl/up.sh
+++ b/scripts/ccf/acl/up.sh
@@ -45,8 +45,7 @@ acl-up() {
         --subscription $SUBSCRIPTION \
         --resource-group $RESOURCE_GROUP \
         --location "AustraliaEast" \
-        --ledger-type "Public" \
-        --aad-based-security-principals ledger-role-name="Administrator" principal-id="$(az account show | jq -r '.id')"
+        --ledger-type "Public"
     export KMS_URL="https://$DEPLOYMENT_NAME.confidential-ledger.azure.com"
 
     # Save the service certificate

--- a/scripts/ccf/acl/up.sh
+++ b/scripts/ccf/acl/up.sh
@@ -41,14 +41,22 @@ acl-up() {
     # Create a member cert
     export KMS_MEMBER_CERT_PATH="$WORKSPACE/member0_cert.pem"
     export KMS_MEMBER_PRIVK_PATH="$WORKSPACE/member0_privk.pem"
-    acl-user-local-cert-create member0
+    if [[ $USE_AKV == false ]]; then
+        acl-user-local-cert-create member0
+    else
+        acl-user-akv-cert-create member0
+    fi
     acl-user-create \
         $(cert-fingerprint $KMS_MEMBER_CERT_PATH) '["Administrator"]'
 
     # Create a user cert
     export KMS_USER_CERT_PATH="$WORKSPACE/user0_cert.pem"
     export KMS_USER_PRIVK_PATH="$WORKSPACE/user0_privk.pem"
-    acl-user-local-cert-create user0
+    if [[ $USE_AKV == false ]]; then
+        acl-user-local-cert-create user0
+    else
+        acl-user-akv-cert-create user0
+    fi
     acl-user-create \
         $(cert-fingerprint $KMS_USER_CERT_PATH) '["Reader"]'
 

--- a/scripts/ccf/acl/user_create.sh
+++ b/scripts/ccf/acl/user_create.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+REPO_ROOT="$(realpath "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../../..")"
+
+cert-fingerprint() {
+    openssl x509 -in "$1" -noout -fingerprint -sha256 | cut -d "=" -f 2
+}
+
+acl-user-local-cert-create() {
+    openssl ecparam -out "$WORKSPACE/$1_privk.pem" -name "secp384r1" -genkey
+    openssl req -new -key "$WORKSPACE/$1_privk.pem" -x509 -nodes -days 365 -out "$WORKSPACE/$1_cert.pem" -"sha384" -subj=/CN="ACL Client Cert"
+}
+
+acl-user-akv-cert-create() {
+    az keyvault certificate create \
+        --vault-name $AKV_VAULT_NAME \
+        --name $1 \
+        --policy "${AKV_POLICY:-$(cat $REPO_ROOT/scripts/akv/key_policy.json | jq -c .)}"
+    rm -rf $WORKSPACE/$1_cert.pem
+    az keyvault certificate download \
+        --vault-name $AKV_VAULT_NAME \
+        --name $1 \
+        --file $WORKSPACE/$1_cert.pem
+}
+
+acl-user-create() {
+    local member_id=$1
+    local roles=$2
+
+    curl $KMS_URL/app/ledgerUsers/$member_id?api-version=2024-08-22-preview \
+        --cacert $KMS_SERVICE_CERT_PATH \
+        -X PATCH \
+        -H "Content-Type: application/merge-patch+json" \
+        -H "Authorization: Bearer $(az account get-access-token --resource https://confidential-ledger.azure.com --query accessToken -o tsv)" \
+        -d "$(jq -n --arg member_id "$member_id" --argjson roles "$roles" '{
+            user_id: $member_id,
+            assignedRoles: $roles
+        }')"
+}
+

--- a/scripts/kms/endpoints/proposals.sh
+++ b/scripts/kms/endpoints/proposals.sh
@@ -6,11 +6,9 @@
 proposals() {
     curl $KMS_URL/app/proposals \
         -X POST \
-        -H "Content-Type: application/json" \
-        -d @"$@" \
+        -H "Content-Type: application/cose" \
+        --data-binary @- \
         --cacert $KMS_SERVICE_CERT_PATH \
-        --cert $KMS_MEMBER_CERT_PATH \
-        --key $KMS_MEMBER_PRIVK_PATH \
         -w '\n%{http_code}\n'
 }
 

--- a/scripts/kms/endpoints/proposals.sh
+++ b/scripts/kms/endpoints/proposals.sh
@@ -6,7 +6,14 @@
 proposals() {
     USE_AKV=${USE_AKV:-false}
 
-    if [[ "$USE_AKV" == false ]]; then
+    if [[ "$KMS_URL" == *"confidential-ledger.azure.com" ]]; then
+        curl $KMS_URL/app/proposals \
+            -X POST \
+            -H "Content-Type: application/cose" \
+            --data-binary @- \
+            --cacert $KMS_SERVICE_CERT_PATH \
+            -w '\n%{http_code}\n'
+    else
         curl $KMS_URL/app/proposals \
             -X POST \
             -H "Content-Type: application/json" \
@@ -14,13 +21,6 @@ proposals() {
             --cacert $KMS_SERVICE_CERT_PATH \
             --cert $KMS_MEMBER_CERT_PATH \
             --key $KMS_MEMBER_PRIVK_PATH \
-            -w '\n%{http_code}\n'
-    else
-        curl $KMS_URL/app/proposals \
-            -X POST \
-            -H "Content-Type: application/cose" \
-            --data-binary @- \
-            --cacert $KMS_SERVICE_CERT_PATH \
             -w '\n%{http_code}\n'
     fi
 }

--- a/scripts/kms/endpoints/proposals.sh
+++ b/scripts/kms/endpoints/proposals.sh
@@ -4,12 +4,25 @@
 # Licensed under the MIT license.
 
 proposals() {
-    curl $KMS_URL/app/proposals \
-        -X POST \
-        -H "Content-Type: application/cose" \
-        --data-binary @- \
-        --cacert $KMS_SERVICE_CERT_PATH \
-        -w '\n%{http_code}\n'
+    USE_AKV=${USE_AKV:-false}
+
+    if [[ "$USE_AKV" == false ]]; then
+        curl $KMS_URL/app/proposals \
+            -X POST \
+            -H "Content-Type: application/json" \
+            -d @"$@" \
+            --cacert $KMS_SERVICE_CERT_PATH \
+            --cert $KMS_MEMBER_CERT_PATH \
+            --key $KMS_MEMBER_PRIVK_PATH \
+            -w '\n%{http_code}\n'
+    else
+        curl $KMS_URL/app/proposals \
+            -X POST \
+            -H "Content-Type: application/cose" \
+            --data-binary @- \
+            --cacert $KMS_SERVICE_CERT_PATH \
+            -w '\n%{http_code}\n'
+    fi
 }
 
 proposals "$@"

--- a/scripts/kms/jwt_issuer_trust.sh
+++ b/scripts/kms/jwt_issuer_trust.sh
@@ -5,7 +5,6 @@
 
 REPO_ROOT="$(realpath "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../..")"
 source $REPO_ROOT/scripts/ccf/sign.sh
-USE_AKV=${USE_AKV:-false}
 
 decode_jwt() {
 
@@ -60,13 +59,13 @@ set_jwt_validation_policy() {
     | jq > $WORKSPACE/proposals/set_jwt_validation_policy.json
 
   # Submit the proposal
-  if [[ $USE_AKV == false ]]; then
-    $REPO_ROOT/scripts/kms/endpoints/proposals.sh \
-      $WORKSPACE/proposals/set_jwt_validation_policy.json
-  else
-    AKV_KEY_NAME="member0" ccf-sign \
+  if [[ "$KMS_URL" == *"confidential-ledger.azure.com" ]]; then
+    AKV_KEY_NAME="user0" ccf-sign \
       $WORKSPACE/proposals/set_jwt_validation_policy.json \
         | $REPO_ROOT/scripts/kms/endpoints/proposals.sh
+  else
+    $REPO_ROOT/scripts/kms/endpoints/proposals.sh \
+      $WORKSPACE/proposals/set_jwt_validation_policy.json
   fi
 
   set +e

--- a/scripts/kms/jwt_issuer_trust.sh
+++ b/scripts/kms/jwt_issuer_trust.sh
@@ -4,6 +4,7 @@
 # Licensed under the MIT license.
 
 REPO_ROOT="$(realpath "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../..")"
+source $REPO_ROOT/scripts/ccf/sign.sh
 
 decode_jwt() {
 
@@ -58,8 +59,9 @@ set_jwt_validation_policy() {
     | jq > $WORKSPACE/proposals/set_jwt_validation_policy.json
 
   # Submit the proposal
-  $REPO_ROOT/scripts/kms/endpoints/proposals.sh \
-    $WORKSPACE/proposals/set_jwt_validation_policy.json
+  AKV_KEY_NAME="member0" ccf-sign \
+    $WORKSPACE/proposals/set_jwt_validation_policy.json \
+    | $REPO_ROOT/scripts/kms/endpoints/proposals.sh
 
   set +e
 }

--- a/scripts/kms/jwt_issuer_trust.sh
+++ b/scripts/kms/jwt_issuer_trust.sh
@@ -5,6 +5,7 @@
 
 REPO_ROOT="$(realpath "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../..")"
 source $REPO_ROOT/scripts/ccf/sign.sh
+USE_AKV=${USE_AKV:-false}
 
 decode_jwt() {
 
@@ -59,9 +60,14 @@ set_jwt_validation_policy() {
     | jq > $WORKSPACE/proposals/set_jwt_validation_policy.json
 
   # Submit the proposal
-  AKV_KEY_NAME="member0" ccf-sign \
-    $WORKSPACE/proposals/set_jwt_validation_policy.json \
-    | $REPO_ROOT/scripts/kms/endpoints/proposals.sh
+  if [[ $USE_AKV == false ]]; then
+    $REPO_ROOT/scripts/kms/endpoints/proposals.sh \
+      $WORKSPACE/proposals/set_jwt_validation_policy.json
+  else
+    AKV_KEY_NAME="member0" ccf-sign \
+      $WORKSPACE/proposals/set_jwt_validation_policy.json \
+        | $REPO_ROOT/scripts/kms/endpoints/proposals.sh
+  fi
 
   set +e
 }

--- a/scripts/kms/key_rotation_policy_set.sh
+++ b/scripts/kms/key_rotation_policy_set.sh
@@ -5,7 +5,6 @@ key_rotation_policy_set() {
 
     REPO_ROOT="$(realpath "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../..")"
     source $REPO_ROOT/scripts/ccf/sign.sh
-    USE_AKV=${USE_AKV:-false}
     ROTATION_POLICY_PROPOSAL=$1
 
     # If rotation policy is not set, use default from the proposal file
@@ -17,13 +16,13 @@ key_rotation_policy_set() {
     echo "$ROTATION_POLICY" | jq > "$WORKSPACE/proposals/set_key_rotation_policy.json"
 
     # Submit the proposal
-    if [[ $USE_AKV == false ]]; then
-        $REPO_ROOT/scripts/kms/endpoints/proposals.sh \
-            $WORKSPACE/proposals/set_key_rotation_policy.json
-    else
-        AKV_KEY_NAME="member0" ccf-sign \
+    if [[ "$KMS_URL" == *"confidential-ledger.azure.com" ]]; then
+        AKV_KEY_NAME="user0" ccf-sign \
             "$WORKSPACE/proposals/set_key_rotation_policy.json" \
                 | $REPO_ROOT/scripts/kms/endpoints/proposals.sh
+    else
+        $REPO_ROOT/scripts/kms/endpoints/proposals.sh \
+            $WORKSPACE/proposals/set_key_rotation_policy.json
     fi
 
 

--- a/scripts/kms/key_rotation_policy_set.sh
+++ b/scripts/kms/key_rotation_policy_set.sh
@@ -4,6 +4,7 @@ key_rotation_policy_set() {
     set -e
 
     REPO_ROOT="$(realpath "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../..")"
+    source $REPO_ROOT/scripts/ccf/sign.sh
     ROTATION_POLICY_PROPOSAL=$1
 
     # If rotation policy is not set, use default from the proposal file
@@ -15,8 +16,9 @@ key_rotation_policy_set() {
     echo "$ROTATION_POLICY" | jq > "$WORKSPACE/proposals/set_key_rotation_policy.json"
 
     # Submit the proposal
-    source $REPO_ROOT/scripts/kms/endpoints/proposals.sh \
-        "$WORKSPACE/proposals/set_key_rotation_policy.json"
+    AKV_KEY_NAME="member0" ccf-sign \
+        "$WORKSPACE/proposals/set_key_rotation_policy.json" \
+        | $REPO_ROOT/scripts/kms/endpoints/proposals.sh
 
     set +e
 }

--- a/scripts/kms/key_rotation_policy_set.sh
+++ b/scripts/kms/key_rotation_policy_set.sh
@@ -5,6 +5,7 @@ key_rotation_policy_set() {
 
     REPO_ROOT="$(realpath "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../..")"
     source $REPO_ROOT/scripts/ccf/sign.sh
+    USE_AKV=${USE_AKV:-false}
     ROTATION_POLICY_PROPOSAL=$1
 
     # If rotation policy is not set, use default from the proposal file
@@ -16,9 +17,15 @@ key_rotation_policy_set() {
     echo "$ROTATION_POLICY" | jq > "$WORKSPACE/proposals/set_key_rotation_policy.json"
 
     # Submit the proposal
-    AKV_KEY_NAME="member0" ccf-sign \
-        "$WORKSPACE/proposals/set_key_rotation_policy.json" \
-        | $REPO_ROOT/scripts/kms/endpoints/proposals.sh
+    if [[ $USE_AKV == false ]]; then
+        $REPO_ROOT/scripts/kms/endpoints/proposals.sh \
+            $WORKSPACE/proposals/set_key_rotation_policy.json
+    else
+        AKV_KEY_NAME="member0" ccf-sign \
+            "$WORKSPACE/proposals/set_key_rotation_policy.json" \
+                | $REPO_ROOT/scripts/kms/endpoints/proposals.sh
+    fi
+
 
     set +e
 }

--- a/scripts/kms/release_policy_set.sh
+++ b/scripts/kms/release_policy_set.sh
@@ -13,8 +13,9 @@ release-policy-set() {
     cp $REPO_ROOT/$RELEASE_POLICY_PROPOSAL $WORKSPACE/proposals/set_key_release_policy.json
 
     # Submit the proposal
-    source $REPO_ROOT/scripts/kms/endpoints/proposals.sh \
-        $WORKSPACE/proposals/set_key_release_policy.json
+    AKV_KEY_NAME="member0" ccf-sign \
+        "$WORKSPACE/proposals/set_key_release_policy.json" \
+        | $REPO_ROOT/scripts/kms/endpoints/proposals.sh
 
     set +e
 }

--- a/scripts/kms/release_policy_set.sh
+++ b/scripts/kms/release_policy_set.sh
@@ -7,15 +7,21 @@ release-policy-set() {
     set -e
 
     REPO_ROOT="$(realpath "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../..")"
+    USE_AKV=${USE_AKV:-false}
     RELEASE_POLICY_PROPOSAL=$1
 
     # Construct the proposal
     cp $REPO_ROOT/$RELEASE_POLICY_PROPOSAL $WORKSPACE/proposals/set_key_release_policy.json
 
     # Submit the proposal
-    AKV_KEY_NAME="member0" ccf-sign \
-        "$WORKSPACE/proposals/set_key_release_policy.json" \
-        | $REPO_ROOT/scripts/kms/endpoints/proposals.sh
+    if [[ $USE_AKV == false ]]; then
+        $REPO_ROOT/scripts/kms/endpoints/proposals.sh \
+            $WORKSPACE/proposals/set_key_release_policy.json
+    else
+        AKV_KEY_NAME="member0" ccf-sign \
+            "$WORKSPACE/proposals/set_key_release_policy.json" \
+                | $REPO_ROOT/scripts/kms/endpoints/proposals.sh
+    fi
 
     set +e
 }

--- a/scripts/kms/release_policy_set.sh
+++ b/scripts/kms/release_policy_set.sh
@@ -7,20 +7,20 @@ release-policy-set() {
     set -e
 
     REPO_ROOT="$(realpath "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../..")"
-    USE_AKV=${USE_AKV:-false}
+    source $REPO_ROOT/scripts/ccf/sign.sh
     RELEASE_POLICY_PROPOSAL=$1
 
     # Construct the proposal
     cp $REPO_ROOT/$RELEASE_POLICY_PROPOSAL $WORKSPACE/proposals/set_key_release_policy.json
 
     # Submit the proposal
-    if [[ $USE_AKV == false ]]; then
-        $REPO_ROOT/scripts/kms/endpoints/proposals.sh \
-            $WORKSPACE/proposals/set_key_release_policy.json
-    else
-        AKV_KEY_NAME="member0" ccf-sign \
+    if [[ "$KMS_URL" == *"confidential-ledger.azure.com" ]]; then
+        AKV_KEY_NAME="user0" ccf-sign \
             "$WORKSPACE/proposals/set_key_release_policy.json" \
                 | $REPO_ROOT/scripts/kms/endpoints/proposals.sh
+    else
+        $REPO_ROOT/scripts/kms/endpoints/proposals.sh \
+            $WORKSPACE/proposals/set_key_release_policy.json
     fi
 
     set +e

--- a/scripts/kms/settings_policy_set.sh
+++ b/scripts/kms/settings_policy_set.sh
@@ -26,8 +26,9 @@ settings-policy-set() {
 
     # Submit the proposal
     result=$(mktemp)
-    source $REPO_ROOT/scripts/kms/endpoints/proposals.sh \
-        $WORKSPACE/proposals/set_settings_policy.json | tee $result
+    AKV_KEY_NAME="member0" ccf-sign \
+        "$WORKSPACE/proposals/set_settings_policy.json" \
+        | $REPO_ROOT/scripts/kms/endpoints/proposals.sh | tee $result
 
     # Check if the last line of result is 200
     if [ "$(tail -n 1 $result)" -ne 200 ]; then

--- a/scripts/kms/settings_policy_set.sh
+++ b/scripts/kms/settings_policy_set.sh
@@ -8,7 +8,7 @@ settings-policy-set() {
     set -e
 
     REPO_ROOT="$(realpath "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../..")"
-    USE_AKV=${USE_AKV:-false}
+    source $REPO_ROOT/scripts/ccf/sign.sh
 
     # If settings policy not set, use default
     if [ -z "$SETTINGS_POLICY" ]; then
@@ -27,13 +27,13 @@ settings-policy-set() {
 
     # Submit the proposal
     result=$(mktemp)
-    if [[ $USE_AKV == false ]]; then
-        $REPO_ROOT/scripts/kms/endpoints/proposals.sh \
-            $WORKSPACE/proposals/set_settings_policy.json | tee $result
-    else
-        AKV_KEY_NAME="member0" ccf-sign \
+    if [[ "$KMS_URL" == *"confidential-ledger.azure.com" ]]; then
+        AKV_KEY_NAME="user0" ccf-sign \
             "$WORKSPACE/proposals/set_settings_policy.json" \
                 | $REPO_ROOT/scripts/kms/endpoints/proposals.sh | tee $result
+    else
+        $REPO_ROOT/scripts/kms/endpoints/proposals.sh \
+            $WORKSPACE/proposals/set_settings_policy.json | tee $result
     fi
 
     # Check if the last line of result is 200

--- a/scripts/kms/settings_policy_set.sh
+++ b/scripts/kms/settings_policy_set.sh
@@ -8,6 +8,7 @@ settings-policy-set() {
     set -e
 
     REPO_ROOT="$(realpath "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../..")"
+    USE_AKV=${USE_AKV:-false}
 
     # If settings policy not set, use default
     if [ -z "$SETTINGS_POLICY" ]; then
@@ -26,9 +27,14 @@ settings-policy-set() {
 
     # Submit the proposal
     result=$(mktemp)
-    AKV_KEY_NAME="member0" ccf-sign \
-        "$WORKSPACE/proposals/set_settings_policy.json" \
-        | $REPO_ROOT/scripts/kms/endpoints/proposals.sh | tee $result
+    if [[ $USE_AKV == false ]]; then
+        $REPO_ROOT/scripts/kms/endpoints/proposals.sh \
+            $WORKSPACE/proposals/set_settings_policy.json | tee $result
+    else
+        AKV_KEY_NAME="member0" ccf-sign \
+            "$WORKSPACE/proposals/set_settings_policy.json" \
+                | $REPO_ROOT/scripts/kms/endpoints/proposals.sh | tee $result
+    fi
 
     # Check if the last line of result is 200
     if [ "$(tail -n 1 $result)" -ne 200 ]; then

--- a/src/authorization/AuthenticationService.ts
+++ b/src/authorization/AuthenticationService.ts
@@ -9,6 +9,7 @@ import { IValidatorService } from "./IValidationService";
 import { UserCertValidator } from "./certs/UserCertValidator";
 import { MemberCertValidator } from "./certs/MemberCertValidator";
 import { Logger, LogContext } from "../utils/Logger";
+import { UserCoseValidator } from "./cose/UserCoseValidator";
 
 /**
  * CCF authentication policies
@@ -18,6 +19,7 @@ export enum CcfAuthenticationPolicyEnum {
   User_signature = "user_signature",
   Member_cert = "member_cert",
   Member_signature = "member_signature",
+  User_cose_sign1 = "user_cose_sign1",
   Jwt = "jwt",
 }
 
@@ -41,6 +43,10 @@ export class AuthenticationService implements IAuthenticationService {
     this.validators.set(
       CcfAuthenticationPolicyEnum.Member_cert,
       new MemberCertValidator(this.logContext),
+    );
+    this.validators.set(
+      CcfAuthenticationPolicyEnum.User_cose_sign1,
+      new UserCoseValidator(this.logContext),
     );
   }
 

--- a/src/authorization/cose/UserCoseValidator.ts
+++ b/src/authorization/cose/UserCoseValidator.ts
@@ -6,7 +6,6 @@ import { ccf } from "@microsoft/ccf-app/global";
 import { IValidatorService } from "../IValidationService";
 import { ServiceResult } from "../../utils/ServiceResult";
 import { LogContext } from "../../utils/Logger";
-import { createHash } from "crypto";
 
 export class UserCoseValidator implements IValidatorService {
   private logContext: LogContext;

--- a/src/authorization/cose/UserCoseValidator.ts
+++ b/src/authorization/cose/UserCoseValidator.ts
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import * as ccfapp from "@microsoft/ccf-app";
+import { ccf } from "@microsoft/ccf-app/global";
+import { IValidatorService } from "../IValidationService";
+import { ServiceResult } from "../../utils/ServiceResult";
+import { LogContext } from "../../utils/Logger";
+import { createHash } from "crypto";
+
+export class UserCoseValidator implements IValidatorService {
+  private logContext: LogContext;
+
+  constructor(logContext?: LogContext) {
+    this.logContext = (logContext?.clone() || new LogContext()).appendScope("UserCoseValidator");
+  }
+
+  validate(request: ccfapp.Request<any>): ServiceResult<string> {
+    if (request.caller === null || request.caller === undefined) {
+      return ServiceResult.Failed({
+        errorMessage: "No caller provided for COSE signature",
+      }, 401, this.logContext );
+    }
+
+    const caller = request.caller;
+    if (caller.policy !== "user_cose_sign1") {
+      return ServiceResult.Failed({
+        errorMessage: "Policy is not user_cose_sign1",
+      }, 401, this.logContext );
+    }
+
+    const c: ccfapp.UserCOSESign1AuthnIdentity = caller;
+    if (
+      request.body.arrayBuffer().byteLength > 0 &&
+      c.cose.content.byteLength == 0
+    ) {
+      return ServiceResult.Failed({
+        errorMessage: "No cose content to validate",
+      }, 401, this.logContext );
+    }
+
+    const isValid = this.isUser(c.id);
+    if (isValid.failure) {
+      return ServiceResult.Failed({
+        errorMessage: `Error: invalid caller identity (UserCoseValidator)->${JSON.stringify(isValid)}`,
+        errorType: "AuthenticationError",
+      }, 401, this.logContext );
+    }
+
+    return ServiceResult.Succeeded(c.id, this.logContext);
+  }
+
+  /**
+   * Checks if a user exists
+   * @see https://microsoft.github.io/CCF/main/audit/builtin_maps.html#users-info
+   * @param {string} userId userId to check if it exists
+   * @returns {ServiceResult<boolean>}
+   */
+  public isUser(userId: string): ServiceResult<boolean> {
+    const usersCerts = ccfapp.typedKv(
+      "public:ccf.gov.users.certs",
+      ccfapp.arrayBuffer,
+      ccfapp.arrayBuffer,
+    );
+    const result = usersCerts.has(ccf.strToBuf(userId));
+    return ServiceResult.Succeeded(result, this.logContext);
+  }
+}

--- a/src/endpoints/proposals.ts
+++ b/src/endpoints/proposals.ts
@@ -91,9 +91,23 @@ export const proposals = (
             callerId = acl.certUtils.convertToAclFingerprintFormat();
         } else if (isAuthType(request.caller!, "jwt")) {
             callerId = (request.caller! as ccfapp.JwtAuthnIdentity).jwt.payload.oid;
+        } else if (isAuthType(request.caller!, "user_cose_sign1")) {
+            // Convert from 12ab34cd format to 12:AB:34:CD
+            callerId = (request.caller! as ccfapp.UserCOSESign1AuthnIdentity).id
+                .toUpperCase()
+                .match(/.{1,2}/g)
+                ?.join(":")!;
         } else {
             return ServiceResult.Failed<IProposalResult[]>(
                 { errorMessage: "Unexpected member_cert auth on ACL" },
+                500,
+                logContext,
+            );
+        }
+
+        if (callerId === undefined || callerId == "") {
+            return ServiceResult.Failed<IProposalResult[]>(
+                { errorMessage: "Caller ID is undefined" },
                 500,
                 logContext,
             );
@@ -127,10 +141,18 @@ export const proposals = (
         );
     }
 
+    // Handle a COSE Sign1 payload
+    let requestBody = serviceRequest.body
+    if (request.caller?.policy === "user_cose_sign1") {
+        requestBody = ccf.bufToJsonCompatible(
+            (request.caller as ccfapp.UserCOSESign1AuthnIdentity).cose.content
+        );
+    }
+
     // Extract settings policy from request
     let proposalActions: IProposalsAction[] = [];
-    if (serviceRequest.body && serviceRequest.body["actions"]) {
-        proposalActions = serviceRequest.body["actions"];
+    if (requestBody && requestBody["actions"]) {
+        proposalActions = requestBody["actions"];
     }
 
     let proposalResults: IProposalResult[] = [];

--- a/test/system-test/conftest.py
+++ b/test/system-test/conftest.py
@@ -156,10 +156,10 @@ def _setup_kms():
 
 
 @pytest.fixture()
-def setup_kms(setup_ccf, setup_akv):
+def setup_kms(setup_akv, setup_ccf):
     yield from _setup_kms()
 
 
 @pytest.fixture(scope="session")
-def setup_kms_session(setup_ccf_session, setup_akv):
+def setup_kms_session(setup_akv, setup_ccf_session):
     yield from _setup_kms()

--- a/test/system-test/conftest.py
+++ b/test/system-test/conftest.py
@@ -145,7 +145,7 @@ def setup_ccf_session():
 
 
 def _setup_kms():
-    if USE_AKV:
+    if USE_AKV and os.getenv("TEST_ENVIRONMENT") == "ccf/sandbox_local":
         call_script([
             "./scripts/akv/key-import.sh",
             "user0"

--- a/test/system-test/conftest.py
+++ b/test/system-test/conftest.py
@@ -148,7 +148,7 @@ def _setup_kms():
     if USE_AKV:
         call_script([
             "./scripts/akv/key-import.sh",
-            f'{os.getenv("DEPLOYMENT_NAME", "kms")}-private-key'
+            "user0"
         ])
     deploy_app_code()
     yield {}


### PR DESCRIPTION
Addresses #421 

### Why

There is a chicken and egg problem setting the JWT validation policy using a JWT, and since production KMS cannot use local certs, we need to have AKV based certs for this proposal.

Since we never want to store the keys locally, that means we need to support COSE signing the proposals much like we did for the `/gov/proposals` endpoint.


### How 
- [x] In `ccf/acl/up.sh`, switch on the value of `USE_AKV` and when set to true create identities in AKV
- [x] Update the KMS application code to be capable of handling `user_cose_sign1` authn_policies
  - [x] Create a new validator for this policy
  - [x] Parse out the body of the COSE sign1 document after validation
- [x] Default the proposals wrapper script to use COSE sign auth and update callers appropriately