### PR TITLE
Remove redundant settings policy setting

### DIFF
--- a/test/system-test/test_unwrapkey.py
+++ b/test/system-test/test_unwrapkey.py
@@ -2,7 +2,7 @@ import json
 import os
 import pytest
 from endpoints import key, refresh, unwrapKey
-from utils import apply_kms_constitution, apply_key_release_policy, trust_jwt_issuer, get_test_attestation, get_test_public_wrapping_key, decrypted_wrapped_key, apply_settings_policy
+from utils import apply_kms_constitution, apply_key_release_policy, trust_jwt_issuer, get_test_attestation, get_test_public_wrapping_key, decrypted_wrapped_key
 
 # This test will check the two step google protocol to retrieve a private key
 # Step 1, call the /key endpoint and retrieve the kid
@@ -13,7 +13,6 @@ from utils import apply_kms_constitution, apply_key_release_policy, trust_jwt_is
 def test_unwrap_key_and_decrypt(setup_kms):
     apply_kms_constitution()
     apply_key_release_policy()
-    apply_settings_policy()
     refresh()
     while True:
         status_code, key_json = key(
@@ -40,7 +39,6 @@ def test_unwrap_key_and_decrypt(setup_kms):
 def test_unwrap_key_missing_attestation(setup_kms):
     apply_kms_constitution()
     apply_key_release_policy()
-    apply_settings_policy()
     refresh()
     while True:
         status_code, key_json = key(
@@ -63,7 +61,6 @@ def test_unwrap_key_missing_attestation(setup_kms):
 def test_unwrap_key_missing_wrapping_key(setup_kms):
     apply_kms_constitution()
     apply_key_release_policy()
-    apply_settings_policy()
     refresh()
     while True:
         status_code, key_json = key(
@@ -86,7 +83,6 @@ def test_unwrap_key_missing_wrapping_key(setup_kms):
 def test_unwrap_key_missing_wrappedKid(setup_kms):
     apply_kms_constitution()
     apply_key_release_policy()
-    apply_settings_policy()
     refresh()
 
     # unwrap key


### PR DESCRIPTION
### Why

While testing ACL based KMS's, Slava was led to believe by our tests for `/unwrapKey` that setting the settings policy is required for the endpoint to work, which it isn't. 

This lost him time and makes the tests expand their coverage outside of their intended domain unnecessarily, it would be confusing if these tests failed because setting the settings policy had a bug.

### How

Remove the calls to `set_settings_policy.sh`