### PR TITLE
Allow acl/up.sh to be called repeatedly without recreating the ACL

### DIFF
--- a/scripts/ccf/acl/up.sh
+++ b/scripts/ccf/acl/up.sh
@@ -32,7 +32,7 @@ acl-up() {
         case "$1" in
             --force-recreate)
                 force_recreate=true
-                shift 2
+                shift
                 ;;
             *)
                 echo "Unknown parameter: $1"


### PR DESCRIPTION
### Why

If the user wants to hook into an already running ACL based KMS, perhaps in a second terminal, they have to manually export all the env variables which `up.sh` exports.

The other `up.sh` scripts also have the behaviour that running again with the same service described just confirms they're running and exports the environment for you, `acl/up.sh` should match this behaviour

### How
- [x] Add checks for cert/key existence and only create new certs if they don't already exist (for the deployment described by the user)
- [x] Only call the az cli command to create an ACL if there isn't already one by the name described by the user
- [x] Add an arg to the script `--force-recreate` which mimics the same arg in docker compose which our tests use to ensure we do recreate everything as before