### PR TITLE
Default to JWT auth in testing

### DIFF
--- a/scripts/kms/endpoints/key.sh
+++ b/scripts/kms/endpoints/key.sh
@@ -5,7 +5,7 @@
 
 key() {
     params=()
-    auth="user_cert"
+    auth="jwt"
     attestation=""
     wrappingKey=""
 

--- a/scripts/kms/endpoints/keyReleasePolicy.sh
+++ b/scripts/kms/endpoints/keyReleasePolicy.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT license.
 
 keyReleasePolicy() {
-    auth="user_cert"
+    auth="jwt"
 
     # Parse command-line arguments
     while [[ $# -gt 0 ]]; do

--- a/scripts/kms/endpoints/settingsPolicy.sh
+++ b/scripts/kms/endpoints/settingsPolicy.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT license.
 
 settingsPolicy() {
-    auth="user_cert"
+    auth="jwt"
 
     # Parse command-line arguments
     while [[ $# -gt 0 ]]; do

--- a/scripts/kms/endpoints/unwrapKey.sh
+++ b/scripts/kms/endpoints/unwrapKey.sh
@@ -5,7 +5,7 @@
 
 unwrap_key() {
     params=()
-    auth="user_cert"
+    auth="jwt"
     attestation=""
     wrappedKid=""
     wrappingKey=""

--- a/test/system-test/conftest.py
+++ b/test/system-test/conftest.py
@@ -8,7 +8,7 @@ import uuid
 
 import pytest
 
-from utils import deploy_app_code
+from utils import deploy_app_code, trust_jwt_issuer
 
 REPO_ROOT = os.path.realpath(os.path.join(os.path.dirname(__file__), "..", ".."))
 TEST_ENVIRONMENT = os.getenv("TEST_ENVIRONMENT", "ccf/sandbox_local")
@@ -151,15 +151,16 @@ def _setup_kms():
             f'{os.getenv("DEPLOYMENT_NAME", "kms")}-private-key'
         ])
     deploy_app_code()
+    trust_jwt_issuer("aad")
     yield {}
     print("") # Prevents cleanup overwriting result
 
 
 @pytest.fixture()
-def setup_kms(setup_ccf, setup_akv):
+def setup_kms(setup_akv, setup_aad_jwt_issuer, setup_ccf):
     yield from _setup_kms()
 
 
 @pytest.fixture(scope="session")
-def setup_kms_session(setup_ccf_session, setup_akv):
+def setup_kms_session(setup_akv, setup_aad_jwt_issuer_session, setup_ccf_session):
     yield from _setup_kms()

--- a/test/system-test/test_all_seq.py
+++ b/test/system-test/test_all_seq.py
@@ -342,15 +342,6 @@ def test_set_policy_single_key_no_jwt_auth_user_cert(setup_kms_session):
     assert auth_json["auth"]["policy"] == "user_cert"
 
 
-def test_set_policy_single_key_no_jwt_auth_jwt(setup_kms_session):
-    try:
-        status_code, auth_json = auth(auth="jwt")
-        assert status_code == 401
-    except CalledProcessError:
-        with pytest.raises(CalledProcessError):
-            raise
-
-
 def test_set_policy_single_key_no_jwt_trust_jwt_issuer(setup_kms_session, setup_aad_jwt_issuer_session):
     trust_jwt_issuer("aad")
 


### PR DESCRIPTION
### Why

When we support ACL with no local certs, this means many tests which rely on local certs will break. Those tests aren't specifically testing local certs so we can just default our authentication policy to JWT to avert this issue

### How
- [x] In the wrapper scripts which default to user or member cert auth, change that default to jwt
- [x] Update test setup to always trust the AAD JWT issuer
- [x] Remove a test which assumes no JWT issuer is currently trusted since that is now never the case 