### PR TITLE
Fix calling unwrapKey.sh from bash

### DIFF
--- a/scripts/kms/endpoints/unwrapKey.sh
+++ b/scripts/kms/endpoints/unwrapKey.sh
@@ -50,7 +50,12 @@ unwrap_key() {
         --cacert $KMS_SERVICE_CERT_PATH \
         "${auth_arg[@]}" \
         -H "Content-Type: application/json" \
-        -d "{\"attestation\":$attestation, \"wrappedKid\":\"$wrappedKid\", \"wrapped\":\"\", \"wrappingKey\":$wrappingKey}" \
+        -d '{
+            "attestation": '"$attestation"',
+            "wrappedKid": "'"$wrappedKid"'",
+            "wrapped": "",
+            "wrappingKey": "'"$wrappingKey"'\n"
+        }' \
         -w '\n%{http_code}\n'
 }
 

--- a/test/system-test/test_all_seq.py
+++ b/test/system-test/test_all_seq.py
@@ -2,8 +2,8 @@ import json
 import os
 import pytest
 from subprocess import CalledProcessError
-from endpoints import heartbeat, key, listpubkeys, pubkey, keyReleasePolicy, unwrapKey, refresh, auth, settingsPolicy
-from utils import get_test_attestation, get_test_public_wrapping_key, apply_kms_constitution, apply_key_release_policy, decrypted_wrapped_key, trust_jwt_issuer, remove_key_release_policy, apply_settings_policy
+from endpoints import heartbeat, key, listpubkeys, pubkey, keyReleasePolicy, refresh, auth, settingsPolicy
+from utils import get_test_attestation, get_test_public_wrapping_key, apply_kms_constitution, apply_key_release_policy, decrypted_wrapped_key, trust_jwt_issuer, remove_key_release_policy, apply_settings_policy, call_endpoint
 
 # These tests run on a single KMS instance in order to be cheaper regarding
 # Azure deployments.
@@ -184,11 +184,12 @@ def test_set_policy_single_key_no_jwt_unwrapKey(setup_kms_session):
     assert status_code == 200
 
     while True:
-        status_code, unwrapped_json = unwrapKey(
-            attestation=get_test_attestation(),
-            wrapping_key=get_test_public_wrapping_key(),
-            wrappedKid=key_json["wrappedKid"],
-        )
+        status_code, unwrapped_json = call_endpoint(fr"""
+            scripts/kms/endpoints/unwrapKey.sh \
+                --attestation "$(cat test/attestation-samples/snp.json)" \
+                --wrapping-key "$(sed ':a;N;$!ba;s/\n/\\n/g' test/data-samples/publicWrapKey.pem)" \
+                --wrappedKid "{key_json["wrappedKid"]}"
+        """)
         if status_code != 202:
             break
     assert status_code == 200
@@ -444,11 +445,12 @@ def test_set_policy_multiple_keys_set_jwt_unwrapKey_no_kid(setup_kms_session):
     assert key_json["wrappedKid"].endswith("_2")
 
     while True:
-        status_code, unwrapped_json = unwrapKey(
-            attestation=get_test_attestation(),
-            wrapping_key=get_test_public_wrapping_key(),
-            wrappedKid=key_json["wrappedKid"],
-        )
+        status_code, unwrapped_json = call_endpoint(fr"""
+            scripts/kms/endpoints/unwrapKey.sh \
+                --attestation "$(cat test/attestation-samples/snp.json)" \
+                --wrapping-key "$(sed ':a;N;$!ba;s/\n/\\n/g' test/data-samples/publicWrapKey.pem)" \
+                --wrappedKid "{key_json["wrappedKid"]}"
+        """)
         if status_code != 202:
             break
     assert status_code == 200
@@ -471,11 +473,12 @@ def test_set_policy_multiple_keys_set_jwt_unwrapKey_first_kid(setup_kms_session)
     assert key_json["wrappedKid"].endswith("_1")
 
     while True:
-        status_code, unwrapped_json = unwrapKey(
-            attestation=get_test_attestation(),
-            wrapping_key=get_test_public_wrapping_key(),
-            wrappedKid=key_json["wrappedKid"],
-        )
+        status_code, unwrapped_json = call_endpoint(fr"""
+            scripts/kms/endpoints/unwrapKey.sh \
+                --attestation "$(cat test/attestation-samples/snp.json)" \
+                --wrapping-key "$(sed ':a;N;$!ba;s/\n/\\n/g' test/data-samples/publicWrapKey.pem)" \
+                --wrappedKid "{key_json["wrappedKid"]}"
+        """)
         if status_code != 202:
             break
     assert status_code == 200

--- a/test/system-test/test_keyRotationPolicy.py
+++ b/test/system-test/test_keyRotationPolicy.py
@@ -2,7 +2,7 @@ import json
 import os
 import pytest
 import time
-from endpoints import key, refresh, unwrapKey
+from endpoints import key, refresh
 from utils import (
     apply_kms_constitution,
     apply_settings_policy,
@@ -11,6 +11,7 @@ from utils import (
     get_test_attestation,
     get_test_public_wrapping_key,
     decrypted_wrapped_key,
+    call_endpoint,
 )
 
 
@@ -39,11 +40,12 @@ def test_key_in_grace_period_with_rotation_policy(setup_kms):
     assert status_code == 200
 
     # unwrap key
-    status_code, unwrapped_json = unwrapKey(
-        attestation=get_test_attestation(),
-        wrapping_key=get_test_public_wrapping_key(),
-        wrappedKid=key_json["wrappedKid"],
-    )
+    status_code, unwrapped_json = call_endpoint(fr"""
+        scripts/kms/endpoints/unwrapKey.sh \
+            --attestation "$(cat test/attestation-samples/snp.json)" \
+            --wrapping-key "$(sed ':a;N;$!ba;s/\n/\\n/g' test/data-samples/publicWrapKey.pem)" \
+            --wrappedKid "{key_json["wrappedKid"]}"
+    """)
     assert status_code == 200
     unwrapped = decrypted_wrapped_key(unwrapped_json["wrapped"])
     unwrapped_json = json.loads(unwrapped)
@@ -66,11 +68,12 @@ def test_key_in_grace_period_without_rotation_policy(setup_kms):
     assert status_code == 200
 
     # unwrap key
-    status_code, unwrapped_json = unwrapKey(
-        attestation=get_test_attestation(),
-        wrapping_key=get_test_public_wrapping_key(),
-        wrappedKid=key_json["wrappedKid"]
-    )
+    status_code, unwrapped_json = call_endpoint(fr"""
+        scripts/kms/endpoints/unwrapKey.sh \
+            --attestation "$(cat test/attestation-samples/snp.json)" \
+            --wrapping-key "$(sed ':a;N;$!ba;s/\n/\\n/g' test/data-samples/publicWrapKey.pem)" \
+            --wrappedKid "{key_json["wrappedKid"]}"
+    """)
     assert status_code == 200
     unwrapped = decrypted_wrapped_key(unwrapped_json["wrapped"])
     unwrapped_json = json.loads(unwrapped)
@@ -95,11 +98,12 @@ def test_key_in_grace_period_with_custom_rotation_policy(setup_kms):
     assert status_code == 200
 
     # unwrap key
-    status_code, unwrapped_json = unwrapKey(
-        attestation=get_test_attestation(),
-        wrapping_key=get_test_public_wrapping_key(),
-        wrappedKid=key_json["wrappedKid"],
-    )
+    status_code, unwrapped_json = call_endpoint(fr"""
+        scripts/kms/endpoints/unwrapKey.sh \
+            --attestation "$(cat test/attestation-samples/snp.json)" \
+            --wrapping-key "$(sed ':a;N;$!ba;s/\n/\\n/g' test/data-samples/publicWrapKey.pem)" \
+            --wrappedKid "{key_json["wrappedKid"]}"
+    """)
     assert status_code == 200
     unwrapped = decrypted_wrapped_key(unwrapped_json["wrapped"])
     unwrapped_json = json.loads(unwrapped)
@@ -119,20 +123,22 @@ def test_key_in_grace_period_with_custom_rotation_policy(setup_kms):
         ]
     }
     apply_key_rotation_policy(policy)
-    status_code, unwrapped_json = unwrapKey(
-        attestation=get_test_attestation(),
-        wrapping_key=get_test_public_wrapping_key(),
-        wrappedKid=key_json["wrappedKid"],
-    )
+    status_code, unwrapped_json = call_endpoint(fr"""
+        scripts/kms/endpoints/unwrapKey.sh \
+            --attestation "$(cat test/attestation-samples/snp.json)" \
+            --wrapping-key "$(sed ':a;N;$!ba;s/\n/\\n/g' test/data-samples/publicWrapKey.pem)" \
+            --wrappedKid "{key_json["wrappedKid"]}"
+    """)
     assert status_code == 200
 
     # wait for the key to expire
     time.sleep(20)
-    status_code, unwrapped_json = unwrapKey(
-        attestation=get_test_attestation(),
-        wrapping_key=get_test_public_wrapping_key(),
-        wrappedKid=key_json["wrappedKid"],
-    )
+    status_code, unwrapped_json = call_endpoint(fr"""
+        scripts/kms/endpoints/unwrapKey.sh \
+            --attestation "$(cat test/attestation-samples/snp.json)" \
+            --wrapping-key "$(sed ':a;N;$!ba;s/\n/\\n/g' test/data-samples/publicWrapKey.pem)" \
+            --wrappedKid "{key_json["wrappedKid"]}"
+    """)
     assert status_code == 410  # check for expired key
 
 

--- a/test/system-test/test_unwrapkey.py
+++ b/test/system-test/test_unwrapkey.py
@@ -1,8 +1,7 @@
 import json
-import os
 import pytest
-from endpoints import key, refresh, unwrapKey
-from utils import apply_kms_constitution, apply_key_release_policy, trust_jwt_issuer, get_test_attestation, get_test_public_wrapping_key, decrypted_wrapped_key, apply_settings_policy
+from endpoints import key, refresh
+from utils import apply_kms_constitution, apply_key_release_policy, trust_jwt_issuer, get_test_attestation, get_test_public_wrapping_key, decrypted_wrapped_key, apply_settings_policy, call_endpoint
 
 # This test will check the two step google protocol to retrieve a private key
 # Step 1, call the /key endpoint and retrieve the kid
@@ -25,11 +24,12 @@ def test_unwrap_key_and_decrypt(setup_kms):
     assert status_code == 200
 
     # unwrap key
-    status_code, unwrapped_json = unwrapKey(
-        attestation=get_test_attestation(),
-        wrapping_key=get_test_public_wrapping_key(),
-        wrappedKid=key_json["wrappedKid"]
-    )
+    status_code, unwrapped_json = call_endpoint(fr"""
+        scripts/kms/endpoints/unwrapKey.sh \
+            --attestation "$(cat test/attestation-samples/snp.json)" \
+            --wrapping-key "$(sed ':a;N;$!ba;s/\n/\\n/g' test/data-samples/publicWrapKey.pem)" \
+            --wrappedKid "{key_json["wrappedKid"]}"
+    """)
     assert status_code == 200
     unwrapped = decrypted_wrapped_key(unwrapped_json["wrapped"])
     unwrapped_json = json.loads(unwrapped)
@@ -52,11 +52,12 @@ def test_unwrap_key_missing_attestation(setup_kms):
     assert status_code == 200
 
     # unwrap key
-    status_code, unwrapped_json = unwrapKey(
-        attestation="abc",
-        wrapping_key=get_test_public_wrapping_key(),
-        wrappedKid=key_json["wrappedKid"]
-    )
+    status_code, unwrapped_json = call_endpoint(fr"""
+        scripts/kms/endpoints/unwrapKey.sh \
+            --attestation "abc" \
+            --wrapping-key "$(sed ':a;N;$!ba;s/\n/\\n/g' test/data-samples/publicWrapKey.pem)" \
+            --wrappedKid "{key_json["wrappedKid"]}"
+    """)
     assert status_code == 400
 
 
@@ -75,11 +76,12 @@ def test_unwrap_key_missing_wrapping_key(setup_kms):
     assert status_code == 200
 
     # unwrap key
-    status_code, unwrapped_json = unwrapKey(
-        attestation=get_test_attestation(),
-        wrapping_key="abc",
-        wrappedKid=key_json["wrappedKid"]
-    )
+    status_code, unwrapped_json = call_endpoint(fr"""
+        scripts/kms/endpoints/unwrapKey.sh \
+            --attestation "$(cat test/attestation-samples/snp.json)" \
+            --wrapping-key "abc" \
+            --wrappedKid "{key_json["wrappedKid"]}"
+    """)
     assert status_code == 400
 
 
@@ -90,11 +92,12 @@ def test_unwrap_key_missing_wrappedKid(setup_kms):
     refresh()
 
     # unwrap key
-    status_code, unwrapped_json = unwrapKey(
-        attestation=get_test_attestation(),
-        wrapping_key=get_test_public_wrapping_key(),
-        wrappedKid=""
-    )
+    status_code, unwrapped_json = call_endpoint(fr"""
+        scripts/kms/endpoints/unwrapKey.sh \
+            --attestation "$(cat test/attestation-samples/snp.json)" \
+            --wrapping-key "$(sed ':a;N;$!ba;s/\n/\\n/g' test/data-samples/publicWrapKey.pem)" \
+            --wrappedKid ""
+    """)
     assert status_code == 404
 
 
@@ -103,14 +106,15 @@ def test_unwrap_key_without_refresh(setup_kms):
     apply_key_release_policy()
 
     # unwrap key
-    status_code, unwrapped_json = unwrapKey(
-        attestation=get_test_attestation(),
-        wrapping_key=get_test_public_wrapping_key(),
-        wrappedKid="abcd"
-    )
+    status_code, unwrapped_json = call_endpoint(fr"""
+        scripts/kms/endpoints/unwrapKey.sh \
+            --attestation "$(cat test/attestation-samples/snp.json)" \
+            --wrapping-key "$(sed ':a;N;$!ba;s/\n/\\n/g' test/data-samples/publicWrapKey.pem)" \
+            --wrappedKid "abc"
+    """)
     assert status_code == 404
 
 
 if __name__ == "__main__":
     import pytest
-    pytest.main([__file__, "-s"])
+    pytest.main([f"{__file__}", "-s"])

--- a/test/system-test/utils.py
+++ b/test/system-test/utils.py
@@ -29,6 +29,24 @@ def deploy_app_code(**kwargs):
     )
 
 
+def call_endpoint(command):
+    *response, status_code = subprocess.run(
+        command,
+        cwd=os.path.realpath(os.path.join(os.path.dirname(__file__), "..", "..")),
+        stdout=subprocess.PIPE,
+        shell=True,
+    ).stdout.decode().splitlines()
+
+    print(f'Called "{" ".join(command)}"')
+    print(f"Response Code: {status_code}")
+    print(f'Response Body: {json.loads("".join(response) or "{}")}')
+
+    return (
+        int(status_code),
+        json.loads("".join(response) or '{}'),
+    )
+
+
 def apply_settings_policy(policy=None):
     subprocess.run(
         "./scripts/kms/settings_policy_set.sh",


### PR DESCRIPTION
### Why

We noticed calling unwrapKey.sh from bash was returning 400. After investigation this turned out to be because bash command substitution removed the trailing newline from the wrappingKey. This didn't happen in tests because we weren't executing in a shell and any other caller is just making the raw HTTP request

### How
- [x] Add back the trailing newline in the wrapper script
- [x] Update tests to use a shell to catch this kind of issue in the future

I've only made the testing change for unwrap key to speed things up but we should do the same for the other endpoints. It is better to see the exact bash being called for reproducability 