### PR TITLE
Refactor the standalone image to remove hardcoded proposals

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,20 +22,11 @@ RUN npm install && npm run build
 # While KMS relies on running on sandbox.sh we need to use dev image
 # FROM mcr.microsoft.com/ccf/app/run-js/${CCF_PLATFORM}:${CCF_VERSION}
 FROM ghcr.io/microsoft/ccf/app/dev/${CCF_PLATFORM}:${CCF_VERSION}
-ARG CCF_PLATFORM
 WORKDIR /kms
 
 # Install nodejs for running the dummy JWT issuer
 RUN curl -fsSL https://deb.nodesource.com/setup_current.x | bash - && \
     apt-get install -y nodejs
-
-# Prebuild python venv to speed up start time
-RUN python3 -m venv .venv_ccf_sandbox && \
-    . .venv_ccf_sandbox/bin/activate && \
-    pip install -U -q pip && \
-    VERSION=$(sed 's/^ccf-//' "/opt/ccf_${CCF_PLATFORM}/share/VERSION_LONG") && \
-    pip install -q -U "ccf==$VERSION" && \
-    pip install -q -U -r "/opt/ccf_${CCF_PLATFORM}/bin/requirements.txt"
 
 RUN apt-get update && apt-get install -y gettext
 
@@ -43,6 +34,7 @@ COPY . .
 COPY docker/run_standalone_kms.sh /run.sh
 COPY --from=builder /kms/dist ./dist
 
+ARG CCF_PLATFORM
 ENV CCF_PLATFORM=${CCF_PLATFORM}
 ENV JWT_ISSUER_PORT=3000
 CMD /bin/bash -c '/run.sh'

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,8 +30,6 @@ RUN curl -fsSL https://deb.nodesource.com/setup_current.x | bash - && \
 
 RUN apt-get update && apt-get install -y gettext
 
-RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash
-
 COPY . .
 COPY docker/run_standalone_kms.sh /run.sh
 COPY --from=builder /kms/dist ./dist

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,6 +30,8 @@ RUN curl -fsSL https://deb.nodesource.com/setup_current.x | bash - && \
 
 RUN apt-get update && apt-get install -y gettext
 
+RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash
+
 COPY . .
 COPY docker/run_standalone_kms.sh /run.sh
 COPY --from=builder /kms/dist ./dist

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,11 +22,20 @@ RUN npm install && npm run build
 # While KMS relies on running on sandbox.sh we need to use dev image
 # FROM mcr.microsoft.com/ccf/app/run-js/${CCF_PLATFORM}:${CCF_VERSION}
 FROM ghcr.io/microsoft/ccf/app/dev/${CCF_PLATFORM}:${CCF_VERSION}
+ARG CCF_PLATFORM
 WORKDIR /kms
 
 # Install nodejs for running the dummy JWT issuer
 RUN curl -fsSL https://deb.nodesource.com/setup_current.x | bash - && \
     apt-get install -y nodejs
+
+# Prebuild python venv to speed up start time
+RUN python3 -m venv .venv_ccf_sandbox && \
+    . .venv_ccf_sandbox/bin/activate && \
+    pip install -U -q pip && \
+    VERSION=$(sed 's/^ccf-//' "/opt/ccf_${CCF_PLATFORM}/share/VERSION_LONG") && \
+    pip install -q -U "ccf==$VERSION" && \
+    pip install -q -U -r "/opt/ccf_${CCF_PLATFORM}/bin/requirements.txt"
 
 RUN apt-get update && apt-get install -y gettext
 
@@ -34,7 +43,6 @@ COPY . .
 COPY docker/run_standalone_kms.sh /run.sh
 COPY --from=builder /kms/dist ./dist
 
-ARG CCF_PLATFORM
 ENV CCF_PLATFORM=${CCF_PLATFORM}
 ENV JWT_ISSUER_PORT=3000
 CMD /bin/bash -c '/run.sh'

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,5 +10,3 @@ services:
       test: ["CMD", "curl", "-k", "--fail", "https://localhost:8000/app/listpubkeys"]
       interval: 1s
       retries: 120
-    volumes:
-      - ${HOME}/.azure/:/root/.azure/

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -11,4 +11,4 @@ services:
       interval: 1s
       retries: 120
     volumes:
-      - ~/.azure:/root/.azure
+      - ${HOME}/.azure/:/root/.azure/

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,3 +10,5 @@ services:
       test: ["CMD", "curl", "-k", "--fail", "https://localhost:8000/app/listpubkeys"]
       interval: 1s
       retries: 120
+    volumes:
+      - ${HOME}/.azure/:/root/.azure/

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,3 +10,5 @@ services:
       test: ["CMD", "curl", "-k", "--fail", "https://localhost:8000/app/listpubkeys"]
       interval: 1s
       retries: 120
+    volumes:
+      - ~/.azure:/root/.azure

--- a/docker/run_standalone_kms.sh
+++ b/docker/run_standalone_kms.sh
@@ -28,7 +28,7 @@ run_ccf_network() {
     curl -k -f https://$(jq -r '.primary_rpc_interface' workspace/sandbox_0/0.rpc_addresses)/node/state && \
     test -f workspace/sandbox_common/user0_cert.pem; do
     sleep 1
-  done
+  donez
 }
 
 export WORKSPACE=/kms/workspace
@@ -46,8 +46,11 @@ run_ccf_network "$@"
 . .venv_ccf_sandbox/bin/activate
 
 . ./scripts/kms/js_app_set.sh
-
-timeout 10 bash -c 'until propose_set_js_app; do sleep 1; done'
+retries=10
+until propose_set_js_app; do
+  sleep 1
+  retries=$((retries - 1))
+done
 
 ./scripts/kms/release_policy_set.sh governance/proposals/set_key_release_policy_add.json
 

--- a/docker/run_standalone_kms.sh
+++ b/docker/run_standalone_kms.sh
@@ -12,6 +12,11 @@ export JWT_ISSUER_WORKSPACE=/kms/workspace
 mkdir -p workspace/proposals
 declare -f jwt_issuer_fetch > $JWT_ISSUER_WORKSPACE/fetch.sh
 
+if ! az account show > /dev/null 2>&1; then
+  echo "No Azure CLI login detected. Logging in as a managed identity..."
+  az login --identity
+fi
+
 (cd test/utils/jwt && KMS_WORKSPACE=/kms/workspace nohup npm run start > nohup.out 2>&1 &)
 ./scripts/wait_idp_ready.sh
 
@@ -45,11 +50,11 @@ sleep 20
   --private-key-path "$JWT_ISSUER_WORKSPACE/private.pem" \
   --token "`jwt_issuer_fetch`"
 
-./scripts/kms/jwt_issuer_trust.sh --managed-identity-v1 `
+./scripts/kms/jwt_issuer_trust.sh --managed-identity-v1 "` \
   az identity show --query id -o tsv \
     --resource-group privacy-sandbox-dev \
     --name privacysandbox \
-`
+`"
 
 ./scripts/kms/endpoints/refresh.sh
 

--- a/docker/run_standalone_kms.sh
+++ b/docker/run_standalone_kms.sh
@@ -49,10 +49,15 @@ run_ccf_network
 
 ./scripts/kms/release_policy_set.sh governance/proposals/set_key_release_policy_add.json
 
-./scripts/kms/jwt_issuer_trust.sh --demo
+./scripts/kms/jwt_issuer_trust.sh \
+  --private-key-path "$JWT_ISSUER_WORKSPACE/private.pem" \
+  --token "`jwt_issuer_fetch`"
 
-./scripts/kms/jwt_issuer_trust.sh --managed-identity-v1 \
-  "/subscriptions/85c61f94-8912-4e82-900e-6ab44de9bdf8/resourcegroups/privacy-sandbox-dev/providers/Microsoft.ManagedIdentity/userAssignedIdentities/privacysandbox"
+./scripts/kms/jwt_issuer_trust.sh --managed-identity-v1 `
+  az identity show --query id -o tsv \
+    --resource-group privacy-sandbox-dev \
+    --name privacysandbox \
+`
 
 ./scripts/kms/endpoints/refresh.sh
 

--- a/docker/run_standalone_kms.sh
+++ b/docker/run_standalone_kms.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT license.
 
 jwt_issuer_fetch() {
-    curl -X POST "$(cat /kms/workspace/jwt_issuer_address)/token" \
+    curl -X POST "$(cat $JWT_ISSUER_WORKSPACE/jwt_issuer_address)/token" \
         | jq -r '.access_token'
 }
 export JWT_ISSUER_WORKSPACE=/kms/workspace
@@ -16,9 +16,6 @@ if ! az account show > /dev/null 2>&1; then
   echo "No Azure CLI login detected. Logging in as a managed identity..."
   az login --identity
 fi
-
-(cd test/utils/jwt && KMS_WORKSPACE=/kms/workspace nohup npm run start > nohup.out 2>&1 &)
-./scripts/wait_idp_ready.sh
 
 /opt/ccf_${CCF_PLATFORM}/bin/sandbox.sh \
   --initial-member-count 3 \
@@ -33,7 +30,7 @@ export KMS_MEMBER_PRIVK_PATH=./workspace/sandbox_common/member0_privk.pem
 
 # Wait for the CCF network to start
 until test -f workspace/sandbox_0/0.rpc_addresses && \
-  curl -k -f https://$(jq -r '.primary_rpc_interface' workspace/sandbox_0/0.rpc_addresses)/node/state && \
+  curl -k -f -s https://$(jq -r '.primary_rpc_interface' workspace/sandbox_0/0.rpc_addresses)/node/state && \
   test -f workspace/sandbox_common/user0_cert.pem; do
   sleep 1
 done

--- a/docker/run_standalone_kms.sh
+++ b/docker/run_standalone_kms.sh
@@ -35,6 +35,8 @@ done
 
 source .venv_ccf_sandbox/bin/activate
 
+sleep 20
+
 . ./scripts/kms/js_app_set.sh && propose_set_js_app
 
 ./scripts/kms/release_policy_set.sh governance/proposals/set_key_release_policy_add.json

--- a/docker/run_standalone_kms.sh
+++ b/docker/run_standalone_kms.sh
@@ -7,67 +7,35 @@ jwt_issuer_fetch() {
     curl -X POST "$(cat /kms/workspace/jwt_issuer_address)/token" \
         | jq -r '.access_token'
 }
+export JWT_ISSUER_WORKSPACE=/kms/workspace
 
-run_dummy_jwt_issuer() {
+mkdir -p workspace/proposals
+declare -f jwt_issuer_fetch > $JWT_ISSUER_WORKSPACE/fetch.sh
 
-  (cd test/utils/jwt && KMS_WORKSPACE=/kms/workspace nohup npm run start > nohup.out 2>&1 &)
-  declare -f jwt_issuer_fetch > $JWT_ISSUER_WORKSPACE/fetch.sh
+(cd test/utils/jwt && KMS_WORKSPACE=/kms/workspace nohup npm run start > nohup.out 2>&1 &)
+./scripts/wait_idp_ready.sh
 
-  ./scripts/wait_idp_ready.sh
-}
-
-run_ccf_network() {
-
-  /opt/ccf_${CCF_PLATFORM}/bin/sandbox.sh \
-    --initial-member-count 3 \
-    --initial-user-count 1 \
-    -v --http2 "$@" &
-
-  # Wait for the CCF network to start
-  until test -f workspace/sandbox_0/0.rpc_addresses && \
-    curl -k -f https://$(jq -r '.primary_rpc_interface' workspace/sandbox_0/0.rpc_addresses)/node/state && \
-    test -f workspace/sandbox_common/user0_cert.pem; do
-    sleep 1
-  done
-}
+/opt/ccf_${CCF_PLATFORM}/bin/sandbox.sh \
+  --js-app-bundle ./dist/ \
+  --initial-member-count 3 \
+  --initial-user-count 1 \
+  -v --http2 "$@" &
 
 export WORKSPACE=/kms/workspace
-export JWT_ISSUER_WORKSPACE=/kms/workspace
 export KMS_URL=${KMS_URL:-https://127.0.0.1:8000}
 export KMS_SERVICE_CERT_PATH=./workspace/sandbox_common/service_cert.pem
 export KMS_MEMBER_CERT_PATH=./workspace/sandbox_common/member0_cert.pem
 export KMS_MEMBER_PRIVK_PATH=./workspace/sandbox_common/member0_privk.pem
-mkdir -p workspace/proposals
 
-if ! az account show > /dev/null 2>&1; then
-  echo "No Azure CLI login detected. Logging in as a managed identity..."
-  az login --identity
-fi
+./scripts/kms_wait.sh
 
-run_dummy_jwt_issuer
-
-run_ccf_network "$@"
-
-. .venv_ccf_sandbox/bin/activate
-
-. ./scripts/kms/js_app_set.sh
-retries=10
-until propose_set_js_app; do
-  sleep 1
-  retries=$((retries - 1))
-done
+source .venv_ccf_sandbox/bin/activate
 
 ./scripts/kms/release_policy_set.sh governance/proposals/set_key_release_policy_add.json
 
-./scripts/kms/jwt_issuer_trust.sh \
-  --private-key-path "$JWT_ISSUER_WORKSPACE/private.pem" \
-  --token "`jwt_issuer_fetch`"
+./scripts/kms/jwt_issuer_trust.sh
 
-./scripts/kms/jwt_issuer_trust.sh --managed-identity-v1 `
-  az identity show --query id -o tsv \
-    --resource-group privacy-sandbox-dev \
-    --name privacysandbox \
-`
+make propose-jwt-ms-validation-policy
 
 ./scripts/kms/endpoints/refresh.sh
 

--- a/docker/run_standalone_kms.sh
+++ b/docker/run_standalone_kms.sh
@@ -39,6 +39,11 @@ export KMS_MEMBER_CERT_PATH=./workspace/sandbox_common/member0_cert.pem
 export KMS_MEMBER_PRIVK_PATH=./workspace/sandbox_common/member0_privk.pem
 mkdir -p workspace/proposals
 
+if ! az account show > /dev/null 2>&1; then
+  echo "No Azure CLI login detected. Logging in as a managed identity..."
+  az login --identity
+fi
+
 run_dummy_jwt_issuer
 
 run_ccf_network "$@"

--- a/docker/run_standalone_kms.sh
+++ b/docker/run_standalone_kms.sh
@@ -45,7 +45,11 @@ sleep 20
   --private-key-path "$JWT_ISSUER_WORKSPACE/private.pem" \
   --token "`jwt_issuer_fetch`"
 
-make propose-jwt-ms-validation-policy
+./scripts/kms/jwt_issuer_trust.sh --managed-identity-v1 `
+  az identity show --query id -o tsv \
+    --resource-group privacy-sandbox-dev \
+    --name privacysandbox \
+`
 
 ./scripts/kms/endpoints/refresh.sh
 

--- a/docker/run_standalone_kms.sh
+++ b/docker/run_standalone_kms.sh
@@ -28,7 +28,7 @@ run_ccf_network() {
     curl -k -f https://$(jq -r '.primary_rpc_interface' workspace/sandbox_0/0.rpc_addresses)/node/state && \
     test -f workspace/sandbox_common/user0_cert.pem; do
     sleep 1
-  donez
+  done
 }
 
 export WORKSPACE=/kms/workspace

--- a/docker/run_standalone_kms.sh
+++ b/docker/run_standalone_kms.sh
@@ -3,32 +3,25 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
+jwt_issuer_fetch() {
+    curl -X POST "$(cat /kms/workspace/jwt_issuer_address)/token" \
+        | jq -r '.access_token'
+}
+export JWT_ISSUER_WORKSPACE=/kms/workspace
+
 mkdir -p workspace/proposals
+declare -f jwt_issuer_fetch > $JWT_ISSUER_WORKSPACE/fetch.sh
 
 (cd test/utils/jwt && KMS_WORKSPACE=/kms/workspace nohup npm run start > nohup.out 2>&1 &)
 ./scripts/wait_idp_ready.sh
-
-JWK=$(npx pem-jwk "./workspace/private.pem" | \
-      jq --arg cert "$(cat ./workspace/cert.pem)" '{kty, n, e} + {x5c: [$cert]} + {kid: "Demo IDP kid"}')
-
-cat <<EOF | jq > ./workspace/proposals/set_jwt_issuer.json
-{
-  "issuer": "http://Demo-jwt-issuer",
-  "jwks": {
-    "keys": [
-      $JWK
-    ]
-  }
-}
-EOF
 
 /opt/ccf_${CCF_PLATFORM}/bin/sandbox.sh \
   --js-app-bundle ./dist/ \
   --initial-member-count 3 \
   --initial-user-count 1 \
-  --jwt-issuer workspace/proposals/set_jwt_issuer.json \
   -v --http2 "$@" &
 
+export WORKSPACE=/kms/workspace
 export KMS_URL=${KMS_URL:-https://127.0.0.1:8000}
 export KMS_SERVICE_CERT_PATH=./workspace/sandbox_common/service_cert.pem
 export KMS_MEMBER_CERT_PATH=./workspace/sandbox_common/member0_cert.pem
@@ -36,6 +29,15 @@ export KMS_MEMBER_PRIVK_PATH=./workspace/sandbox_common/member0_privk.pem
 
 ./scripts/kms_wait.sh
 
-make setup
+source .venv_ccf_sandbox/bin/activate
 
-tail -f /kms/workspace/sandbox_0/out
+./scripts/kms/release_policy_set.sh governance/proposals/set_key_release_policy_add.json
+
+./scripts/kms/jwt_issuer_trust.sh
+
+make propose-jwt-ms-validation-policy
+
+./scripts/kms/endpoints/refresh.sh
+
+# tail -f /kms/workspace/sandbox_0/out
+sleep infinity

--- a/docker/run_standalone_kms.sh
+++ b/docker/run_standalone_kms.sh
@@ -3,14 +3,14 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
+jwt_issuer_fetch() {
+    curl -X POST "$(cat /kms/workspace/jwt_issuer_address)/token" \
+        | jq -r '.access_token'
+}
+
 run_dummy_jwt_issuer() {
 
   (cd test/utils/jwt && KMS_WORKSPACE=/kms/workspace nohup npm run start > nohup.out 2>&1 &)
-
-  jwt_issuer_fetch() {
-      curl -X POST "$(cat /kms/workspace/jwt_issuer_address)/token" \
-          | jq -r '.access_token'
-  }
   declare -f jwt_issuer_fetch > $JWT_ISSUER_WORKSPACE/fetch.sh
 
   ./scripts/wait_idp_ready.sh

--- a/docker/run_standalone_kms.sh
+++ b/docker/run_standalone_kms.sh
@@ -16,7 +16,6 @@ declare -f jwt_issuer_fetch > $JWT_ISSUER_WORKSPACE/fetch.sh
 ./scripts/wait_idp_ready.sh
 
 /opt/ccf_${CCF_PLATFORM}/bin/sandbox.sh \
-  --js-app-bundle ./dist/ \
   --initial-member-count 3 \
   --initial-user-count 1 \
   -v --http2 "$@" &
@@ -27,9 +26,16 @@ export KMS_SERVICE_CERT_PATH=./workspace/sandbox_common/service_cert.pem
 export KMS_MEMBER_CERT_PATH=./workspace/sandbox_common/member0_cert.pem
 export KMS_MEMBER_PRIVK_PATH=./workspace/sandbox_common/member0_privk.pem
 
-./scripts/kms_wait.sh
+# Wait for the CCF network to start
+until test -f workspace/sandbox_0/0.rpc_addresses && \
+  curl -k -f https://$(jq -r '.primary_rpc_interface' workspace/sandbox_0/0.rpc_addresses)/node/state && \
+  test -f workspace/sandbox_common/user0_cert.pem; do
+  sleep 1
+done
 
 source .venv_ccf_sandbox/bin/activate
+
+. ./scripts/kms/js_app_set.sh && propose_set_js_app
 
 ./scripts/kms/release_policy_set.sh governance/proposals/set_key_release_policy_add.json
 

--- a/docker/run_standalone_kms.sh
+++ b/docker/run_standalone_kms.sh
@@ -52,7 +52,7 @@ run_ccf_network
 ./scripts/kms/jwt_issuer_trust.sh --demo
 
 ./scripts/kms/jwt_issuer_trust.sh --managed-identity-v1 \
-  $(az identity show --name privacysandbox --resource-group privacy-sandbox-dev --query id -o tsv)
+  "/subscriptions/85c61f94-8912-4e82-900e-6ab44de9bdf8/resourcegroups/privacy-sandbox-dev/providers/Microsoft.ManagedIdentity/userAssignedIdentities/privacysandbox"
 
 ./scripts/kms/endpoints/refresh.sh
 

--- a/docker/run_standalone_kms.sh
+++ b/docker/run_standalone_kms.sh
@@ -45,7 +45,9 @@ run_ccf_network "$@"
 
 . .venv_ccf_sandbox/bin/activate
 
-. ./scripts/kms/js_app_set.sh && propose_set_js_app
+. ./scripts/kms/js_app_set.sh
+
+timeout 10 bash -c 'until propose_set_js_app; do sleep 1; done'
 
 ./scripts/kms/release_policy_set.sh governance/proposals/set_key_release_policy_add.json
 

--- a/docker/run_standalone_kms.sh
+++ b/docker/run_standalone_kms.sh
@@ -41,7 +41,9 @@ sleep 20
 
 ./scripts/kms/release_policy_set.sh governance/proposals/set_key_release_policy_add.json
 
-./scripts/kms/jwt_issuer_trust.sh
+./scripts/kms/jwt_issuer_trust.sh \
+  --private-key-path "$JWT_ISSUER_WORKSPACE/private.pem" \
+  --token "`jwt_issuer_fetch`"
 
 make propose-jwt-ms-validation-policy
 

--- a/docker/run_standalone_kms.sh
+++ b/docker/run_standalone_kms.sh
@@ -34,7 +34,7 @@ done
 
 source .venv_ccf_sandbox/bin/activate
 
-./scripts/kms/js_app_set.sh
+. ./scripts/kms/js_app_set.sh && propose_set_js_app
 
 ./scripts/kms/release_policy_set.sh governance/proposals/set_key_release_policy_add.json
 

--- a/docker/run_standalone_kms.sh
+++ b/docker/run_standalone_kms.sh
@@ -41,7 +41,7 @@ mkdir -p workspace/proposals
 
 run_dummy_jwt_issuer
 
-run_ccf_network
+run_ccf_network "$@"
 
 . .venv_ccf_sandbox/bin/activate
 

--- a/docker/run_standalone_kms.sh
+++ b/docker/run_standalone_kms.sh
@@ -49,9 +49,10 @@ run_ccf_network
 
 ./scripts/kms/release_policy_set.sh governance/proposals/set_key_release_policy_add.json
 
-./scripts/kms/jwt_issuer_trust.sh
+./scripts/kms/jwt_issuer_trust.sh --demo
 
-make propose-jwt-ms-validation-policy
+./scripts/kms/jwt_issuer_trust.sh --managed-identity-v1 \
+  $(az identity show --name privacysandbox --resource-group privacy-sandbox-dev --query id -o tsv)
 
 ./scripts/kms/endpoints/refresh.sh
 

--- a/scripts/ccf/sign.sh
+++ b/scripts/ccf/sign.sh
@@ -16,7 +16,7 @@ ccf-sign() {
             --signing-cert ${KMS_MEMBER_CERT_PATH} \
             --signing-key ${KMS_MEMBER_PRIVK_PATH} \
             --ccf-gov-msg-type $msg_type \
-            --ccf-gov-msg-created_at $(date -Is) \
+            --ccf-gov-msg-created_at $(date -u +"%Y-%m-%dT%H:%M:%S") \
             $extra_args
     else
         creation_time=$(date -u +"%Y-%m-%dT%H:%M:%S")

--- a/scripts/ccf/sign.sh
+++ b/scripts/ccf/sign.sh
@@ -16,7 +16,7 @@ ccf-sign() {
             --signing-cert ${KMS_MEMBER_CERT_PATH} \
             --signing-key ${KMS_MEMBER_PRIVK_PATH} \
             --ccf-gov-msg-type $msg_type \
-            --ccf-gov-msg-created_at $(date -u +"%Y-%m-%dT%H:%M:%S") \
+            --ccf-gov-msg-created_at $(date -Is) \
             $extra_args
     else
         creation_time=$(date -u +"%Y-%m-%dT%H:%M:%S")

--- a/scripts/kms/js_app_set.sh
+++ b/scripts/kms/js_app_set.sh
@@ -3,6 +3,8 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
+REPO_ROOT="$(realpath "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../..")"
+
 propose_set_js_app() {
   # For plain CCF, application code is set via a governance proposal
 
@@ -45,8 +47,6 @@ call_user_defined_endpoints() {
 js-app-set() {
   set -e
 
-  REPO_ROOT="$(realpath "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../..")"
-
   # Build the KMS bundle
   npm install && npm run build
 
@@ -59,4 +59,6 @@ js-app-set() {
   set +e
 }
 
-js-app-set "$@"
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  js-app-set "$@"
+fi

--- a/scripts/kms/js_app_set.sh
+++ b/scripts/kms/js_app_set.sh
@@ -3,6 +3,8 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
+REPO_ROOT="$(realpath "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../..")"
+
 propose_set_js_app() {
   # For plain CCF, application code is set via a governance proposal
 
@@ -43,9 +45,6 @@ call_user_defined_endpoints() {
 
 
 js-app-set() {
-  set -e
-
-  REPO_ROOT="$(realpath "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../..")"
 
   # Build the KMS bundle
   npm install && npm run build
@@ -56,7 +55,8 @@ js-app-set() {
     propose_set_js_app
   fi
 
-  set +e
 }
 
-js-app-set "$@"
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  js-app-set "$@"
+fi

--- a/scripts/kms/js_app_set.sh
+++ b/scripts/kms/js_app_set.sh
@@ -3,8 +3,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT license.
 
-REPO_ROOT="$(realpath "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../..")"
-
 propose_set_js_app() {
   # For plain CCF, application code is set via a governance proposal
 
@@ -47,6 +45,8 @@ call_user_defined_endpoints() {
 js-app-set() {
   set -e
 
+  REPO_ROOT="$(realpath "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/../..")"
+
   # Build the KMS bundle
   npm install && npm run build
 
@@ -59,6 +59,4 @@ js-app-set() {
   set +e
 }
 
-if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
-  js-app-set "$@"
-fi
+js-app-set "$@"

--- a/scripts/kms/jwt_issuer_trust.sh
+++ b/scripts/kms/jwt_issuer_trust.sh
@@ -108,7 +108,6 @@ jwt-issuer-get-policy-from-mi() {
     az identity show --ids $1 | jq '{
         iss: "https://login.microsoftonline.com/\( .tenantId )/v2.0",
         sub: .principalId,
-        name: .name,
         idtyp: "app",
         oid: .principalId
     }'
@@ -118,7 +117,6 @@ jwt-issuer-get-policy-from-mi-v1() {
     az identity show --ids $1 | jq '{
         iss: "https://sts.windows.net/\( .tenantId )/",
         sub: .principalId,
-        name: .name,
         idtyp: "app",
         oid: .principalId
     }'


### PR DESCRIPTION
### Why

This is a step on the path to supporting ACL. 

Supporting ACL requires changing the dataplane shared libraries, in order to avoid rebuilding those images per test I want to merge https://github.com/KenGordon/data-plane-shared-libraries/pull/50. However, since main here and on privacy-sandbox-dev still relies on hard coding the proposal to trust our managed identity, that PR will not pass CI.

This PR alongside https://github.com/microsoft/privacy-sandbox-dev/pull/263 will fix that, allowing me to merge the dataplane PR and therefore iterate on ACL support more quickly

### How
- [x] Update the standalone image to use the newer scripts which don't hardcode any values