### PR TITLE
Expect a v2 MI token in standalone image

### DIFF
--- a/docker/run_standalone_kms.sh
+++ b/docker/run_standalone_kms.sh
@@ -41,7 +41,7 @@ source .venv_ccf_sandbox/bin/activate
       | jq -r '.access_token' \
   `"
 
-./scripts/kms/jwt_issuer_trust.sh --managed-identity-v1 "` \
+./scripts/kms/jwt_issuer_trust.sh --managed-identity "` \
   az identity show --query id -o tsv \
     --resource-group privacy-sandbox-dev \
     --name privacysandbox \


### PR DESCRIPTION
### Why

To facilitate using confidential ledger scoped token in privacy-sandbox-dev, we must configure the KMS to expect the v2 token