### PR TITLE
Ensure proposal timestamps are distinct in tests

### DIFF
--- a/test/system-test/test_proposals.py
+++ b/test/system-test/test_proposals.py
@@ -21,6 +21,9 @@ def test_proposals_multiple(setup_kms):
     assert status_code == 200
     assert len(proposals_json) == 1
 
+    # Sleep to ensure that the proposal timestamps are different so they're ordered correctly
+    sleep(2)
+
     # Make a second proposal
     apply_key_release_policy()
 


### PR DESCRIPTION
### Why

After merging #457 I noticed that sometimes in CI we can get two events by chance which in combination cause `test_proposals.py` to fail.

- In `test_proposals_multiple` the test proposal to set the key release policy can sometimes happen on the same timestamp second as the setup proposal to configure the JWT issuer
- If the timestamps are the same, there is then no way to distinguish the order of the proposals, so the proposal actions are in a non-deterministic order

When both these things happen, the test fails. I noticed the same issue with `test_proposals_caps_to_five` since that submits proposals in a loop and therefore submits them fast enough to always hit point 1 and has a sufficiently large number of proposals to make point 2 almost always happen.

The solution to both is to sleep between proposals to guarantee they will fall on different timestamps